### PR TITLE
[deps] Fix deps scripts to work with external upstream repos

### DIFF
--- a/deps/getrepos
+++ b/deps/getrepos
@@ -3,7 +3,7 @@
 # getrepos: Checks out the repos listed in repos.txt
 
 import os
-import re
+import subprocess
 import sys
 
 cwd = os.getcwd()
@@ -12,29 +12,22 @@ if cwd != srcdir:
     print("Error: getrepos is not in the current directory")
     sys.exit(1)
 
-repos = []
 with open('repos.txt', 'r') as f:
     for line in f:
-        repos.append(line.strip())
-
-with open(os.path.join(srcdir, '../.git/config'), 'r') as conf:
-    match = None
-    for line in conf:
-        match = re.search('url = (.+://.+@.+/otc_zjs-)project', line)
-        if match:
-            break
-
-    if not match:
-        print("Error: unable to find git URL in .git/config")
-        sys.exit(1)
-
-    prefix = match.groups()[0]
-    for repo in repos:
-        if os.path.exists(repo):
-            print("Warning: directory '%s' found, skipping..." % repo)
+        line = line.strip()
+        if not line or  line[0] == '#':
+            continue
+        try:
+            (subdir, repo, commit) = line.split()
+        except ValueError:
+            print("Warning: line %d invalid in repos.txt, skipping..." % count)
             continue
 
-        os.system('git clone %s%s %s' % (prefix, repo, repo))
-        os.chdir(repo)
-        os.system('git checkout origin/zjs')
+        if os.path.exists(subdir):
+            print("Warning: directory '%s' found, skipping..." % subdir)
+            continue
+
+        subprocess.call(['git', 'clone', repo, subdir])
+        os.chdir(subdir)
+        subprocess.call(['git', 'checkout', commit])
         os.chdir('..')

--- a/deps/repos.txt
+++ b/deps/repos.txt
@@ -1,4 +1,5 @@
-jerryscript
-zephyr
-a101fw
-soletta
+# first field: name for deps subdir
+# second field: git URL to clone the repo
+# third field: branch or commit to check out
+jerryscript https://github.com/Samsung/jerryscript.git master
+zephyr https://gerrit.zephyrproject.org/r/zephyr master

--- a/deps/update
+++ b/deps/update
@@ -3,7 +3,7 @@
 # update: Updates the repos listed in repos.txt
 
 import os
-import re
+import subprocess
 import sys
 
 cwd = os.getcwd()
@@ -14,14 +14,21 @@ if cwd != srcdir:
 
 repos = []
 with open('repos.txt', 'r') as f:
+    count = 0
     for line in f:
-        repos.append(line.strip())
+        count += 1
+        line = line.strip()
+        if not line or  line[0] == '#':
+            continue
+        try:
+            (subdir, repo, commit) = line.split()
+        except ValueError:
+            print("Warning: line %d invalid in repos.txt, skipping..." % count)
+            continue
 
-for repo in repos:
-    print("Updating repo '%s':\n" % repo)
-    os.chdir(repo)
-    os.system('git checkout master')
-    os.system('git pull')
-    os.system('git checkout origin/zjs')
-    os.chdir('..')
-    print('');
+        os.chdir(subdir)
+        subprocess.call(['git', 'checkout', 'master'])
+        subprocess.call(['git', 'pull'])
+        if commit != 'master':
+            subprocess.call(['git', 'checkout', commit])
+        os.chdir('..')


### PR DESCRIPTION
The repos.txt file now allows you to specify the branch to check out, so
if we're not in sync with the tips of JerryScript or Zephyr for a time,
we can make sure the build still works. For now, I just set them both to
check out master.

Note: To work with a 256KB x86 partition on Arduino 101 requires a patch
to Zephyr, and I haven't yet figured out how to handle that. I could check
in the patch here and apply it, or I could submit it to Zephyr upstream
but I'm not sure it makes sense for wider consumption at this point.

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
