### PR TITLE
[ARC] Fix ARC build against upstream Zephyr

### DIFF
--- a/arc/src/Makefile
+++ b/arc/src/Makefile
@@ -1,6 +1,5 @@
 ccflags-y += ${PROJECTINCLUDE} \
-	-I$(srctree)/include/drivers \
-	-I$(srctree)/drivers \
+	-I$(ZEPHYR_BASE)/drivers \
 	-I$(src)/../../src \
 	-I$(src)/../../deps/jerryscript/jerry-core
 


### PR DESCRIPTION
Fix build of ARC app that need updated upstream Zephyr changes.

Signed-off-by: Jimmy Huang jimmy.huang@intel.com
