### PR TITLE
[PWM] Use milliseconds in PWM API instead of microseconds

### DIFF
--- a/samples/PWM.js
+++ b/samples/PWM.js
@@ -12,8 +12,8 @@ var pwm = require("pwm");
 var led0 = pwm.open({channel: 0});  // pin IO3
 
 // set timings in microseconds with *US functions
-led0.setPeriodUS(1500000);
-led0.setPulseWidthUS(1000000);
+led0.setPeriod(1500);
+led0.setPulseWidth(1000);
 
 // set brightness to 33% using hw cycle-based values
 var led1 = pwm.open({channel: 1, period: 3, pulseWidth: 1});  // pin IO5
@@ -21,14 +21,14 @@ var led1 = pwm.open({channel: 1, period: 3, pulseWidth: 1});  // pin IO5
 // reproduce the Zephyr PWM sample in JS, changing blink timings every 4s
 var led2 = pwm.open({channel: 2});  // pin IO6
 
-var minPeriod = 1000;  // 1ms
-var maxPeriod = 1000000;  // 1s
+var minPeriod = 1;  // 1ms
+var maxPeriod = 1000;  // 1s
 var period = maxPeriod;
 var dir = 0;
 
 // set initial state
-led2.setPeriodUS(period);
-led2.setPulseWidthUS(period / 2);
+led2.setPeriod(period);
+led2.setPulseWidth(period / 2);
 
 setInterval(function () {
     if (dir) {
@@ -48,6 +48,7 @@ setInterval(function () {
         }
     }
 
-    led2.setPeriodUS(period);
-    led2.setPulseWidthUS(period / 2);
+    led2.setPeriod(period);
+    led2.setPulseWidth(period / 2);
+
 }, 4000);

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -218,8 +218,8 @@ bool zjs_aio_open(const jerry_object_t *function_obj_p,
     zjs_obj_add_function(pinobj, zjs_aio_pin_abort, "abort");
     zjs_obj_add_function(pinobj, zjs_aio_pin_close, "close");
     zjs_obj_add_string(pinobj, name, "name");
-    zjs_obj_add_uint32(pinobj, device, "device");
-    zjs_obj_add_uint32(pinobj, pin, "pin");
+    zjs_obj_add_number(pinobj, device, "device");
+    zjs_obj_add_number(pinobj, pin, "pin");
     zjs_obj_add_boolean(pinobj, raw, "raw");
 
     *ret_val_p = jerry_create_object_value(pinobj);

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -202,7 +202,7 @@ bool zjs_gpio_open(const jerry_object_t *function_obj_p,
     zjs_obj_add_function(pinobj, zjs_gpio_pin_read, "read");
     zjs_obj_add_function(pinobj, zjs_gpio_pin_write, "write");
     zjs_obj_add_function(pinobj, zjs_gpio_pin_set_callback, "set_callback");
-    zjs_obj_add_uint32(pinobj, pin, "pin");
+    zjs_obj_add_number(pinobj, pin, "pin");
     zjs_obj_add_string(pinobj, dirOut ? ZJS_DIR_OUT : ZJS_DIR_IN, "direction");
     zjs_obj_add_boolean(pinobj, activeLow, "activeLow");
     zjs_obj_add_string(pinobj, edge, "edge");

--- a/src/zjs_pwm.h
+++ b/src/zjs_pwm.h
@@ -16,11 +16,11 @@ bool zjs_pwm_pin_set_period(const jerry_object_t *function_obj_p,
                             const jerry_length_t args_cnt,
                             jerry_value_t *ret_val_p);
 
-bool zjs_pwm_pin_set_period_us(const jerry_object_t *function_obj_p,
-                               const jerry_value_t this_val,
-                               const jerry_value_t args_p[],
-                               const jerry_length_t args_cnt,
-                               jerry_value_t *ret_val_p);
+bool zjs_pwm_pin_set_period_cycles(const jerry_object_t *function_obj_p,
+                                   const jerry_value_t this_val,
+                                   const jerry_value_t args_p[],
+                                   const jerry_length_t args_cnt,
+                                   jerry_value_t *ret_val_p);
 
 bool zjs_pwm_pin_set_pulse_width(const jerry_object_t *function_obj_p,
                                  const jerry_value_t this_val,
@@ -28,8 +28,8 @@ bool zjs_pwm_pin_set_pulse_width(const jerry_object_t *function_obj_p,
                                  const jerry_length_t args_cnt,
                                  jerry_value_t *ret_val_p);
 
-bool zjs_pwm_pin_set_pulse_width_us(const jerry_object_t *function_obj_p,
-                                    const jerry_value_t this_val,
-                                    const jerry_value_t args_p[],
-                                    const jerry_length_t args_cnt,
-                                    jerry_value_t *ret_val_p);
+bool zjs_pwm_pin_set_pulse_width_cycles(const jerry_object_t *function_obj_p,
+                                        const jerry_value_t this_val,
+                                        const jerry_value_t args_p[],
+                                        const jerry_length_t args_cnt,
+                                        jerry_value_t *ret_val_p);

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -89,19 +89,18 @@ void zjs_obj_add_string(jerry_object_t *obj, const char *sval,
                         const char *name)
 {
     // requires: obj is an existing JS object
-    //  effects: creates a new field in parent named name, set to value
+    //  effects: creates a new field in parent named name, set to sval
     jerry_string_t *str = jerry_create_string(sval);
     jerry_value_t value = jerry_create_string_value(str);
     jerry_set_object_field_value(obj, name, value);
     jerry_release_value(value);
 }
 
-void zjs_obj_add_uint32(jerry_object_t *obj, uint32_t ival,
-                        const char *name)
+void zjs_obj_add_number(jerry_object_t *obj, double nval, const char *name)
 {
     // requires: obj is an existing JS object
-    //  effects: creates a new field in parent named name, set to value
-    jerry_value_t value = jerry_create_number_value(ival);
+    //  effects: creates a new field in parent named name, set to nval
+    jerry_value_t value = jerry_create_number_value(nval);
     jerry_set_object_field_value(obj, name, value);
 }
 
@@ -145,6 +144,20 @@ bool zjs_obj_get_string(jerry_object_t *obj, const char *name,
 
     int wlen = jerry_string_to_char_buffer(str, buffer, len);
     buffer[wlen] = '\0';
+    jerry_release_value(value);
+    return true;
+}
+
+bool zjs_obj_get_double(jerry_object_t *obj, const char *name,
+                        double *num)
+{
+    // requires: obj is an existing JS object, value name should exist as number
+    //  effects: retrieves field specified by name as a uint32
+    jerry_value_t value = jerry_get_object_field_value(obj, name);
+    if (jerry_value_is_error(value))
+        return false;
+
+    *num = jerry_get_number_value(value);
     jerry_release_value(value);
     return true;
 }

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -33,15 +33,13 @@ void zjs_obj_add_object(jerry_object_t *parent, jerry_object_t *child,
                         const char *name);
 void zjs_obj_add_string(jerry_object_t *obj, const char *value,
                         const char *name);
-void zjs_obj_add_uint32(jerry_object_t *obj, uint32_t value,
-                        const char *name);
+void zjs_obj_add_number(jerry_object_t *obj, double value, const char *name);
 
-bool zjs_obj_get_boolean(jerry_object_t *obj, const char *name,
-                         bool *bval);
-bool zjs_obj_get_string(jerry_object_t *obj, const char *name,
-                        char *buffer, int len);
-bool zjs_obj_get_uint32(jerry_object_t *obj, const char *name,
-                        uint32_t *num);
+bool zjs_obj_get_boolean(jerry_object_t *obj, const char *name, bool *bval);
+bool zjs_obj_get_string(jerry_object_t *obj, const char *name, char *buffer,
+                        int len);
+bool zjs_obj_get_double(jerry_object_t *obj, const char *name, double *num);
+bool zjs_obj_get_uint32(jerry_object_t *obj, const char *name, uint32_t *num);
 
 #define ZJS_IS_BOOL(jval) (jval.type == JERRY_DATA_TYPE_BOOLEAN)
 #define ZJS_IS_FLOAT32(jval) (jval.type == JERRY_DATA_TYPE_FLOAT32)


### PR DESCRIPTION
Following a more web-standard practice, and allowing floats to specify
finer granularity than milliseconds. Also, use term "Cycles" for HW cycle-
dependent APIs.

Report period and pulse width in milliseconds from JS PWM pin object.

Update PWM sample app to use the new APIs.

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
