### PR TITLE
[util] Remove ARC code's dependency on JerryScript headers

### DIFF
--- a/arc/src/Makefile
+++ b/arc/src/Makefile
@@ -1,6 +1,5 @@
 ccflags-y += ${PROJECTINCLUDE} \
 	-I$(ZEPHYR_BASE)/drivers \
 	-I$(src)/../../src \
-	-I$(src)/../../deps/jerryscript/jerry-core
 
 obj-y = main.o ../../src/zjs_ipm.o

--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2016, Intel Corporation.
+
+// This file includes code common to both X86 and ARC
+
+#if defined(CONFIG_STDOUT_CONSOLE)
+#include <stdio.h>
+#define PRINT           printf
+#else
+#include <misc/printk.h>
+#define PRINT           printk
+#endif
+
+// TODO: We should instead have a macro that changes in debug vs. release build,
+// to save string space and instead print error codes or something for release.

--- a/src/zjs_ipm.c
+++ b/src/zjs_ipm.c
@@ -5,7 +5,8 @@
 
 // ZJS includes
 #include "zjs_ipm.h"
-#include "zjs_util.h"
+
+#include "zjs_common.h"
 
 #define IPM_CHANNEL_X86_TO_ARC       1
 #define IPM_CHANNEL_ARC_TO_X86       2

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -1,14 +1,9 @@
 // Copyright (c) 2016, Intel Corporation.
 
-#include "jerry-api.h"
+// The util code is only for the X86 side
 
-#if defined(CONFIG_STDOUT_CONSOLE)
-#include <stdio.h>
-#define PRINT           printf
-#else
-#include <misc/printk.h>
-#define PRINT           printk
-#endif
+#include "jerry-api.h"
+#include "zjs_util.h"
 
 struct zjs_callback;
 
@@ -22,6 +17,8 @@ struct zjs_callback {
     // embed this within your own struct to add data fields you need
 };
 
+// TODO: We may want to reuse the queue code on ARC side at some point, and move
+//   this to zjs_common
 void zjs_queue_init();
 void zjs_queue_callback(struct zjs_callback *cb);
 void zjs_run_pending_callbacks();


### PR DESCRIPTION
This was by slightly reorganizing header files, because the ARC code
doesn't actually use anything from JerryScript so it shouldn't be
dependent on it.

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
