### PR TITLE
[General] Add a magic 'zjs_sleep' variable set from JS to induce sleep

### DIFF
--- a/samples/WebBluetoothDemo.js
+++ b/samples/WebBluetoothDemo.js
@@ -146,3 +146,6 @@ ble.on('disconnect', function(clientAddress) {
 });
 
 print("WebBluetooth Demo with BLE...");
+
+// Set magic value for now to get the main loop to sleep between callbacks
+zjs_sleep = 100;

--- a/samples/tests/ButtonEnable.js
+++ b/samples/tests/ButtonEnable.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2016, Intel Corporation.
 
-// Test code for Arduino 101 that uses two buttons on IO4 and IO5 to control
+// Test code for Arduino 101 that uses two buttons on IO2 and IO4 to control
 // the two onboard LEDs.
 //
 // This version tests freeing a callback by changing the callback of btn2


### PR DESCRIPTION
If this global variable is detected, the main loop will sleep for the
given number of ticks before each call to run pending callbacks. This
make the WebBluetooth demo work, but not sleeping makes all our other
samples work.

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
