### PR TITLE
Fix BLE connection bug

### DIFF
--- a/samples/WebBluetoothDemo.js
+++ b/samples/WebBluetoothDemo.js
@@ -156,6 +156,3 @@ ble.on('disconnect', function(clientAddress) {
 });
 
 print("WebBluetooth Demo with BLE...");
-
-// Set magic value for now to get the main loop to sleep between callbacks
-zjs_sleep = 100;

--- a/src/main.c
+++ b/src/main.c
@@ -65,14 +65,6 @@ void main(int argc, char *argv[])
     // This is needed to make WebBluetooth demo work for now, but breaks all
     //   our other samples if we just do it all the time.
     jerry_value_t global_obj = jerry_get_global_object();
-    double dsleep;
-    int32_t isleep = 0;
-    if (zjs_obj_get_double(global_obj, "zjs_sleep", &dsleep)) {
-        isleep = (int32_t)dsleep;
-        if (isleep) {
-            PRINT("Found magic sleep value: %ld!\n", isleep);
-        }
-    }
     jerry_release_value(global_obj);
     jerry_release_value(code_eval);
     jerry_release_value(result);
@@ -83,10 +75,6 @@ void main(int argc, char *argv[])
 
     while (1) {
         zjs_timers_process_events();
-        if (isleep) {
-            // sleep here temporary fixes the BLE bug
-            task_sleep(isleep);
-        }
         zjs_run_pending_callbacks();
         zjs_service_callbacks();
         // not sure if this is okay, but it seems better to sleep than

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -485,8 +485,6 @@ static void zjs_ble_connected(struct bt_conn *conn, uint8_t err)
     } else {
         zjs_ble_default_conn = bt_conn_ref(conn);
         PRINT("Connected\n");
-        // FIXME: temporary fix for BLE bug
-        fiber_sleep(100);
         zjs_ble_queue_dispatch("accept", zjs_ble_accept_call_function, 0);
     }
 }


### PR DESCRIPTION
The bug was caused by macro used in registration did not allocate memory on the heap and was freed after the stack popped. 
