### PR TITLE
[GPIO] Restore synchronous GPIO open API; openAsync for async version

### DIFF
--- a/samples/ButtonLEDs-k64f.js
+++ b/samples/ButtonLEDs-k64f.js
@@ -11,35 +11,24 @@ print("GPIO test with two LEDs and a button...");
 var gpio = require("gpio");
 var pins = require("k64f_pins");
 
-var pinA = null;
-var pinB = null;
-
 // D0 - D13 will also work as these output pins, if you hook up an LED
-gpio.open({ pin: pins.LEDR }).then(function(pin) {
-    pinA = pin;
-});
-
-gpio.open({ pin: pins.LEDB }).then(function(pin) {
-    pinB = pin;
-});
+var pinA = gpio.open({ pin: pins.LEDR });
+var pinB = gpio.open({ pin: pins.LEDB });
 
 // D0 - D15 will also work as this input pin, if you hook up a button
-gpio.open({ pin: pins.SW2, direction: 'in',
-            edge: 'falling' }).then(function(pin) {
-    // tick is the delay between blinks
-    var tick = 1000, toggle = false;
+var pinIn = gpio.open({ pin: pins.SW2, direction: 'in', edge: 'falling' });
 
-    setInterval(function () {
-        toggle = !toggle;
-        pin.read();
-        pinA.write(toggle);
-        pinB.write(toggle);
-    }, tick);
+// tick is the delay between blinks
+var tick = 1000, toggle = false;
 
-    pin.onchange = function(event) {
-        pinA.write(true);
-        pinB.write(false);
-    };
-}).catch(function(error) {
-    print("Error opening GPIO pin");
-});
+setInterval(function () {
+    toggle = !toggle;
+    pinIn.read();
+    pinA.write(toggle);
+    pinB.write(toggle);
+}, tick);
+
+pinIn.onchange = function(event) {
+    pinA.write(true);
+    pinB.write(false);
+};

--- a/samples/ButtonLEDs.js
+++ b/samples/ButtonLEDs.js
@@ -12,32 +12,21 @@ var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
 // pins 8 (LED0) and 12 (LED1) are onboard LEDs on Arduino 101
-var pinA = null;
-var pinB = null;
+var pinA = gpio.open({ pin: pins.LED0, activeLow: false });
+var pinB = gpio.open({ pin: pins.LED1, activeLow: true });
+var pinIn = gpio.open({ pin: pins.IO4, direction: 'in', edge: 'rising' });
 
-gpio.open({ pin: pins.LED0, activeLow: false }).then(function(pin) {
-    pinA = pin;
-});
+// tick is the delay between blinks
+var tick = 1000, toggle = false;
 
-gpio.open({ pin: pins.LED1, activeLow: true }).then(function(pin) {
-    pinB = pin;
-});
+setInterval(function () {
+    toggle = !toggle;
+    pinIn.read();
+    pinA.write(toggle);
+    pinB.write(toggle);
+}, tick);
 
-gpio.open({ pin: pins.IO4, direction: 'in', edge: 'rising' }).then(function(pin) {
-    // tick is the delay between blinks
-    var tick = 1000, toggle = false;
-
-    setInterval(function () {
-        toggle = !toggle;
-        pin.read();
-        pinA.write(toggle);
-        pinB.write(toggle);
-    }, tick);
-
-    pin.onchange = function(event) {
-        pinA.write(true);
-        pinB.write(false);
-    };
-}).catch(function(error) {
-    print("Error opening GPIO pin");
-});
+pinIn.onchange = function(event) {
+    pinA.write(true);
+    pinB.write(false);
+};

--- a/samples/ButtonLEDsAsync.js
+++ b/samples/ButtonLEDsAsync.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, Intel Corporation.
+
+// This is an asynchronous version of ButtonLEDs.js, calling gpio.openAsync
+
+// Test code for Arduino 101 that uses the two onboard LEDs for output, and
+// expects a button or similar input connected to IO4. Blinks the LEDs on and
+// off together, but when the button is pressed turns one on and one off until
+// the next timer expires.
+
+print("Async GPIO test with two LEDs and a button...");
+
+// import gpio module
+var gpio = require("gpio");
+var pins = require("arduino101_pins");
+
+// pins 8 (LED0) and 12 (LED1) are onboard LEDs on Arduino 101
+var pinA = null;
+var pinB = null;
+
+gpio.openAsync({ pin: pins.LED0, activeLow: false }).then(function(pin) {
+    pinA = pin;
+});
+
+gpio.openAsync({ pin: pins.LED1, activeLow: true }).then(function(pin) {
+    pinB = pin;
+});
+
+gpio.openAsync({ pin: pins.IO4, direction: 'in', edge: 'rising' }).then(function(pin) {
+    // tick is the delay between blinks
+    var tick = 1000, toggle = false;
+
+    setInterval(function () {
+        toggle = !toggle;
+        pin.read();
+        pinA.write(toggle);
+        pinB.write(toggle);
+    }, tick);
+
+    pin.onchange = function(event) {
+        pinA.write(true);
+        pinB.write(false);
+    };
+}).catch(function(error) {
+    print("Error opening GPIO pin");
+});

--- a/samples/TwoButtons.js
+++ b/samples/TwoButtons.js
@@ -14,32 +14,18 @@ var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
 // pins 8 (LED0) and 12 (LED1) are onboard LEDs on Arduino 101
-var led1 = null;
-var led2 = null;
+var led1 = gpio.open({ pin: pins.LED0, activeLow: false });
+var led2 = gpio.open({ pin: pins.LED1, activeLow: true });
+var btn1 = gpio.open({ pin: pins.IO3, direction: 'in', edge: 'any' });
+var btn2 = gpio.open({ pin: pins.IO4, direction: 'in', edge: 'any' });
 
-gpio.open({ pin: pins.LED0, activeLow: false }).then(function(pin) {
-    led1 = pin;
-});
+// turn off LED #2 initially
+led2.write(false);
 
-gpio.open({ pin: pins.LED1, activeLow: true }).then(function(pin) {
-    led2 = pin;
+btn1.onchange = function (event) {
+    led1.write(event.value);
+};
 
-    // turn off LED #2 initially
-    led2.write(false);
-});
-
-gpio.open({ pin: pins.IO3, direction: 'in', edge: 'any' }).then(function(btn1) {
-    btn1.onchange = function (event) {
-        led1.write(event.value);
-    };
-}).catch(function(error) {
-    print("Error opening GPIO pin");
-});
-
-gpio.open({ pin: pins.IO4, direction: 'in', edge: 'any' }).then(function(btn2) {
-    btn2.onchange = function (event) {
-        led2.write(event.value);
-    };
-}).catch(function(error) {
-    print("Error opening GPIO pin");
-});
+btn2.onchange = function (event) {
+    led2.write(event.value);
+};

--- a/samples/arduino/basics/Blink-k64f.js
+++ b/samples/arduino/basics/Blink-k64f.js
@@ -9,15 +9,13 @@ var pins = require("k64f_pins");
 
 // LEDG is the green LED within the RGB LED on the FRDM-K64F
 // 'out' direction is default, could be left out
-gpio.open({pin: pins.D5, direction: 'out'}).then(function(pin) {
-    // remember the current state of the LED
-    var toggle = false;
+var pin = gpio.open({pin: pins.D5, direction: 'out'})
 
-    // schedule a function to run every 1s (1000ms)
-    setInterval(function () {
-        toggle = !toggle;
-        pin.write(toggle);
-    }, 1000);
-}).catch(function(error) {
-    print("Error opening GPIO pin");
-});
+// remember the current state of the LED
+var toggle = false;
+
+// schedule a function to run every 1s (1000ms)
+setInterval(function () {
+    toggle = !toggle;
+    pin.write(toggle);
+}, 1000);

--- a/samples/arduino/basics/Blink.js
+++ b/samples/arduino/basics/Blink.js
@@ -9,15 +9,13 @@ var pins = require("arduino101_pins");
 
 // pin 8 is one of the onboard LEDs on the Arduino 101
 // 'out' direction is default, could be left out
-gpio.open({pin: pins.LED0, direction: 'out'}).then(function(pin) {
-    // remember the current state of the LED
-    var toggle = false;
+var pin = gpio.open({pin: pins.LED0, direction: 'out'});
 
-    // schedule a function to run every 1s (1000ms)
-    setInterval(function () {
-        toggle = !toggle;
-        pin.write(toggle);
-    }, 1000);
-}).catch(function(error) {
-    print("Error opening GPIO pin");
-});
+// remember the current state of the LED
+var toggle = false;
+
+// schedule a function to run every 1s (1000ms)
+setInterval(function () {
+    toggle = !toggle;
+    pin.write(toggle);
+}, 1000);

--- a/samples/arduino/basics/DigitalReadSerial.js
+++ b/samples/arduino/basics/DigitalReadSerial.js
@@ -7,11 +7,9 @@
 var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
-gpio.open({pin: pins.IO4, direction: 'in'}).then(function(pin) {
-    // schedule a function to run every 1s (1000)
-    setInterval(function () {
-        print(pin.read());
-    }, 1000);
-}).catch(function(error) {
-    print("Error opening GPIO pin");
-});
+var pin = gpio.open({pin: pins.IO4, direction: 'in'});
+
+// schedule a function to run every 1s (1000)
+setInterval(function () {
+    print(pin.read());
+}, 1000);

--- a/samples/arduino/digital/Button.js
+++ b/samples/arduino/digital/Button.js
@@ -7,18 +7,9 @@
 var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
-var led = null;
+var led = gpio.open({pin: pins.LED0, direction: 'out'});
+var button = gpio.open({pin: pins.IO4, direction: 'in', edge: 'any'});
 
-gpio.open({pin: pins.LED0, direction: 'out'}).then(function(pin) {
-    led = pin;
-}).docatch(function(error) {
-    print("Error opening LED GPIO pin");
-});
-
-gpio.open({pin: pins.IO4, direction: 'in', edge: 'any'}).then(function(pin) {
-    pin.onchange = function(event) {
-        led.write(event.value);
-    };
-}).catch(function(error) {
-    print("Error opening GPIO pin");
-});
+button.onchange = function(event) {
+    led.write(event.value);
+}


### PR DESCRIPTION
This restores the simplicity of the sample code. Added an async version
of the ButtonLEDs sample to maintain an example of that.

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
