### PR TITLE
[Linux] Added option to build for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,40 @@ gdb:
 arcgdb:
 	$$ZEPHYR_SDK_INSTALL_DIR/sysroots/i686-pokysdk-linux/usr/bin/arc-poky-elf/arc-poky-elf-gdb arc/outdir/zephyr.elf -ex "target remote :3334"
 
+CORE_SRC = 	src/main.c \
+			src/zjs_buffer.c \
+			src/zjs_callbacks.c \
+			src/zjs_linux_time.c \
+			src/zjs_modules.c \
+			src/zjs_script_gen.c \
+			src/zjs_timers.c \
+			src/zjs_util.c
+
+CORE_OBJ =	$(CORE_SRC:%.c=%.o)
+
+LINUX_INCLUDES = 	-Isrc/ \
+					-Ideps/jerryscript/jerry-core
+
+JERRY_LIBS = 		-lrelease.jerry-core -lm
+
+JERRY_LIB_PATH = 	-Ldeps/jerryscript/build/obj/linux/jerry-core/
+
+.PHONY: linux
+ifdef JS
+linux: $(CORE_OBJ) generate
+else
+linux: $(CORE_OBJ)
+endif
+	@echo "Building for Linux $(CORE_OBJ)"
+	cd deps/jerryscript; make release.linux -j;
+	gcc -o main $(CORE_OBJ) $(JERRY_LIB_PATH) $(JERRY_LIBS) $(LINUX_INCLUDES) $(LINUX_DEFINES)
+
+LINUX_DEFINES = -DZJS_LINUX_BUILD
+
+%.o:%.c
+	gcc -c -o $@ $< $(LINUX_INCLUDES) $(LINUX_DEFINES) --verbose
+
+
 .PHONY: help
 help:
 	@echo "Build targets:"

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -1,7 +1,9 @@
 // Copyright (c) 2016, Intel Corporation.
 
+#ifndef ZJS_LINUX_BUILD
 // Zephyr includes
 #include <zephyr.h>
+#endif
 
 #include <string.h>
 
@@ -166,9 +168,9 @@ static void zjs_buffer_callback_free(uintptr_t handle)
     struct zjs_buffer_t **pItem = &zjs_buffers;
     while (*pItem) {
         if ((uintptr_t)*pItem == handle) {
-            task_free((*pItem)->buffer);
+            zjs_free((*pItem)->buffer);
             *pItem = (*pItem)->next;
-            task_free((void *)handle);
+            zjs_free((void *)handle);
         }
         pItem = &(*pItem)->next;
     }
@@ -181,15 +183,15 @@ jerry_value_t zjs_buffer_create(uint32_t size)
     //             list item to track it; if any of these fail, free them all
     //             and return NULL, otherwise return the JS object
     jerry_value_t buf_obj = jerry_create_object();
-    void *buf = task_malloc(size);
+    void *buf = zjs_malloc(size);
     struct zjs_buffer_t *buf_item =
-        (struct zjs_buffer_t *)task_malloc(sizeof(struct zjs_buffer_t));
+        (struct zjs_buffer_t *)zjs_malloc(sizeof(struct zjs_buffer_t));
 
     if (!buf_obj || !buf || !buf_item) {
         PRINT("zjs_buffer_create: unable to allocate buffer\n");
         jerry_release_value(buf_obj);
-        task_free(buf);
-        task_free(buf_item);
+        zjs_free(buf);
+        zjs_free(buf_item);
         return NULL;
     }
 

--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -4,13 +4,17 @@
 #define __zjs_common_h__
 
 // This file includes code common to both X86 and ARC
-
+#ifndef ZJS_LINUX_BUILD
 #if defined(CONFIG_STDOUT_CONSOLE)
 #include <stdio.h>
 #define PRINT           printf
 #else
 #include <misc/printk.h>
 #define PRINT           printk
+#endif
+#else
+#include <stdio.h>
+#define PRINT           printf
 #endif
 
 // TODO: We should instead have a macro that changes in debug vs. release build,

--- a/src/zjs_linux_time.c
+++ b/src/zjs_linux_time.c
@@ -1,0 +1,40 @@
+#include "zjs_linux_time.h"
+#include <time.h>
+#include <unistd.h>
+
+#define ZEPHYR_TICKS_PER_SEC
+
+void zjs_port_timer_init(struct zjs_port_timer* timer, void* data)
+{
+    timer->data = data;
+}
+
+void zjs_port_timer_start(struct zjs_port_timer* timer, uint32_t interval)
+{
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    timer->sec = now.tv_sec;
+    timer->milli = now.tv_nsec / 1000000;
+    timer->interval = interval * 1000 / 100;
+}
+
+void zjs_port_timer_stop(struct zjs_port_timer* timer)
+{
+    timer->interval = 0;
+}
+
+uint8_t zjs_port_timer_test(struct zjs_port_timer* timer, uint32_t ticks)
+{
+    uint32_t elapsed;
+    struct timespec now;
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
+    elapsed = (1000 * (now.tv_sec - timer->sec)) + ((now.tv_nsec / 1000000) - timer->milli);
+
+    if (elapsed >= timer->interval) {
+        return 1;
+    }
+    return 0;
+}
+

--- a/src/zjs_linux_time.h
+++ b/src/zjs_linux_time.h
@@ -1,0 +1,25 @@
+#ifndef ZJS_LINUX_TIME_H_
+#define ZJS_LINUX_TIME_H_
+
+#include "zjs_util.h"
+
+struct zjs_port_timer {
+    uint32_t sec;
+    uint32_t milli;
+    uint32_t interval;
+    void* data;
+};
+
+void zjs_port_timer_init(struct zjs_port_timer* timer, void* data);
+
+void zjs_port_timer_start(struct zjs_port_timer* timer, uint32_t interval);
+
+void zjs_port_timer_stop(struct zjs_port_timer* timer);
+
+uint8_t zjs_port_timer_test(struct zjs_port_timer* timer, uint32_t ticks);
+
+#define ZJS_TICKS_NONE          0
+#define CONFIG_SYS_CLOCK_TICKS_PER_SEC 100
+#define zjs_sleep usleep
+
+#endif /* ZJS_LINUX_TIME_H_ */

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -1,7 +1,9 @@
 // Copyright (c) 2016, Intel Corporation.
 
+#ifndef ZJS_LINUX_BUILD
 // Zephyr includes
 #include <zephyr.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 
@@ -64,7 +66,7 @@ void zjs_modules_init()
 
 void zjs_modules_add(const char *name, InitCB cb)
 {
-    struct modItem *item = (struct modItem *)task_malloc(sizeof(struct modItem));
+    struct modItem *item = (struct modItem *)zjs_malloc(sizeof(struct modItem));
     if (!item) {
         PRINT("Error: out of memory!\n");
         exit(1);

--- a/src/zjs_modules.h
+++ b/src/zjs_modules.h
@@ -3,7 +3,9 @@
 #ifndef __zjs_modules_h__
 #define __zjs_modules_h__
 
+#ifndef ZJS_LINUX_BUILD
 #include <zephyr.h>
+#endif
 
 #include "jerry-api.h"
 

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -1,12 +1,13 @@
 // Copyright (c) 2016, Intel Corporation.
 
-// Zephyr includes
-#include <zephyr.h>
 #include <string.h>
 
 // ZJS includes
 #include "zjs_util.h"
 
+#ifndef ZJS_LINUX_BUILD
+// Zephyr includes
+#include <zephyr.h>
 // fifo of pointers to zjs_callback objects representing JS callbacks
 struct nano_fifo zjs_callbacks_fifo;
 
@@ -51,6 +52,7 @@ void zjs_run_pending_callbacks()
         cb->call_function(cb);
     }
 }
+#endif
 
 void zjs_set_property(const jerry_value_t obj_val, const char *str_p,
                       const jerry_value_t prop_val)

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -16,6 +16,14 @@
 #define DBG_PRINT(fmat ...) do {} while(0);
 #endif
 
+#ifdef ZJS_LINUX_BUILD
+#define zjs_malloc(sz) malloc(sz)
+#define zjs_free(ptr) free(ptr)
+#else
+#define zjs_malloc(sz) task_malloc(sz)
+#define zjs_free(ptr) task_free(ptr)
+#endif
+
 struct zjs_callback;
 
 typedef void (*zjs_cb_wrapper_t)(struct zjs_callback *);

--- a/src/zjs_zephyr_time.h
+++ b/src/zjs_zephyr_time.h
@@ -1,0 +1,14 @@
+#ifndef ZJS_ZEPHYR_TIME_H_
+#define ZJS_ZEPHYR_TIME_H_
+
+#include <zephyr.h>
+
+#define zjs_port_timer          nano_timer
+#define zjs_port_timer_init     nano_timer_init
+#define zjs_port_timer_start    nano_timer_start
+#define zjs_port_timer_stop     nano_task_timer_stop
+#define zjs_port_timer_test     nano_task_timer_test
+#define ZJS_TICKS_NONE          TICKS_NONE
+#define zjs_sleep               task_sleep
+
+#endif /* ZJS_ZEPHYR_TIME_H_ */


### PR DESCRIPTION
- In prep for OCF work, having a linux build will be much easier for
  development. With some minor porting changes/additions you can now
  build for linux:
  
  make linux JS=<script>
- Support is minimal and not extensively tested. I have confirmed that
  HelloWorld.js and Timers.js work, though timers may not be accurate
  due to Zephyr using ticks and linux using real time.

Signed-off-by: James Prestwood james.prestwood@intel.com
