### PR TITLE
[GPIO] Fix memory leak when onchange function is set

### DIFF
--- a/samples/AutoButton.js
+++ b/samples/AutoButton.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2016, Intel Corporation.
+
+// Sample simulates a button click by toggling a GPIO output up and down;
+// Displays the iteration count every 10ms and should run indefinitely.
+
+// This is a useful template for testing for a memory leak or stability
+// problem by counting the number of times it can successfully run before
+// locking up. If "exit" is printed on the serial console, generally this
+// means JerryScript has run out of memory.
+
+// Hardware Requirements:
+//   - Arduino 101
+// Wiring:
+//   - Wire IO12 to IO13
+
+print("Starting AutoButton example...");
+
+// time between iterations (in milliseconds)
+var delay = 10;
+
+// import modules
+var gpio = require("gpio");
+var pins = require("arduino101_pins");
+
+// listen for button presses on this input
+var input = gpio.open({
+    pin: pins.IO11,
+    direction: 'in',
+    edge: 'rising'
+});
+
+// simulate button presses on this output
+var output = gpio.open({
+    pin: pins.IO12,
+    direction: 'out'
+});
+
+var count = 0;
+
+input.onchange = function(event) {
+    count += 1;
+    print("Iteration #" + count);
+    // add code here to test for problems
+}
+
+setInterval(function () {
+    // simulate quick button press
+    output.write(false);
+    output.write(true);
+}, delay);

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -55,27 +55,25 @@ static void gpio_c_callback(void* h)
 
     // If pin.onChange exists, call it
     if (jerry_value_is_function(onchange_func)) {
-        jerry_value_t args[1];
         jerry_value_t event = jerry_create_object();
         // Put the boolean GPIO trigger value in the object
         zjs_obj_add_boolean(event, handle->value, "value");
-
-        jerry_value_t event_val = jerry_acquire_value(event);
-        // Set the args
-        // TODO: can we just use event_val directly when calling the JS function?
-        args[0] = event_val;
 
         // Only aquire once, once we have it just keep using it.
         // It will be released in close()
         if (!handle->onchange_func) {
             handle->onchange_func = jerry_acquire_value(onchange_func);
         }
-        jerry_value_t this_val = jerry_create_undefined();
+
         // Call the JS callback
-        jerry_call_function(handle->onchange_func, this_val, args, 1);
+        jerry_call_function(handle->onchange_func, ZJS_UNDEFINED, &event, 1);
+
+        jerry_release_value(event);
     } else {
         DBG_PRINT("onChange has not been registered\n");
     }
+
+    jerry_release_value(onchange_func);
 }
 
 // Callback when a GPIO input fires


### PR DESCRIPTION
Debugged with James. Also called out in zjs_get_property that the value
returned is owned by the caller and should be released.

Also, add AutoButton.js sample for simulating button presses; useful as a
template for finding memory leaks and such.

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
