### PR TITLE
[general] Added comments to modules/linux #ifdefs

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -5,7 +5,7 @@
 #include "zjs_zephyr_time.h"
 #else
 #include "zjs_linux_time.h"
-#endif
+#endif // ZJS_LINUX_BUILD
 #include <string.h>
 
 // JerryScript includes
@@ -25,7 +25,7 @@
 #include "zjs_util.h"
 #ifdef CONFIG_BOARD_ARDUINO_101
 #include "zjs_a101_pins.h"
-#endif
+#endif // ZJS_LINUX_BUILD
 #ifdef CONFIG_BOARD_FRDM_K64F
 #include "zjs_k64f_pins.h"
 #endif

--- a/src/zjs_a101_pins.c
+++ b/src/zjs_a101_pins.c
@@ -112,4 +112,4 @@ jerry_value_t zjs_a101_init()
 
     return obj;
 }
-#endif
+#endif // BUILD_MODULE_A101

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -361,5 +361,5 @@ jerry_value_t zjs_aio_init()
     return aio_obj;
 }
 
-#endif
-#endif
+#endif // QEMU_BUILD
+#endif // BUILD_MODULE_AIO

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -379,4 +379,4 @@ jerry_value_t zjs_gpio_init()
     zjs_obj_add_function(gpio_obj, zjs_gpio_open_async, "openAsync");
     return gpio_obj;
 }
-#endif
+#endif // BUILD_MODULE_GPIO

--- a/src/zjs_ipm.c
+++ b/src/zjs_ipm.c
@@ -53,4 +53,4 @@ void zjs_ipm_register_callback(uint32_t msg_id, ipm_callback_t cb) {
     ipm_set_enabled(ipm_receive_dev, 1);
 }
 
-#endif
+#endif // QEMU_BUILD

--- a/src/zjs_pwm.c
+++ b/src/zjs_pwm.c
@@ -275,4 +275,4 @@ jerry_value_t zjs_pwm_init()
     zjs_obj_add_function(pwm_obj, zjs_pwm_open, "open");
     return pwm_obj;
 }
-#endif
+#endif // BUILD_MODULE_PWM

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -48,7 +48,7 @@ void zjs_run_pending_callbacks()
         cb->call_function(cb);
     }
 }
-#endif
+#endif // ZJS_LINUX_BUILD
 
 void zjs_set_property(const jerry_value_t obj_val, const char *str_p,
                       const jerry_value_t prop_val)


### PR DESCRIPTION
- The long/nested #ifdefs were confusing without comments at the #endif

Signed-off-by: James Prestwood james.prestwood@intel.com
