### PR TITLE
[Timers] Fix setTimeout, broken by a recent patch.

### DIFF
--- a/samples/Timers.js
+++ b/samples/Timers.js
@@ -1,4 +1,14 @@
-var count = 0;
+// Copyright (c) 2016, Intel Corporation.
+
+// Example using setInterval and setTimeout, passing arguments
+// The timeout should stop the setInterval timer after five times
+
+// Hardware Requirements:
+//   - None
+
+print("Starting Timers example...");
+
+var count = 1;
 
 var i = setInterval(function(a, b) {
     print("Interval #" + count + ' arg1: ' + a + ' arg2: ' + b);


### PR DESCRIPTION
The timer object for setTimeout and its callback were being deleted before
it had actually run.

Also, add comments to Timers.js sample.

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
