### PR TITLE
[Cleanup] Standardize JS native callback argument names

### DIFF
--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -228,14 +228,14 @@ static void ipm_msg_receive_callback(void *context, uint32_t id, volatile void *
     }
 }
 
-static jerry_value_t zjs_aio_pin_read(const jerry_value_t function_obj_val,
-                                      const jerry_value_t this_val,
-                                      const jerry_value_t args_p[],
-                                      const jerry_length_t args_cnt)
+static jerry_value_t zjs_aio_pin_read(const jerry_value_t function_obj,
+                                      const jerry_value_t this,
+                                      const jerry_value_t argv[],
+                                      const jerry_length_t argc)
 {
     uint32_t device, pin;
-    zjs_obj_get_uint32(this_val, "device", &device);
-    zjs_obj_get_uint32(this_val, "pin", &pin);
+    zjs_obj_get_uint32(this, "device", &device);
+    zjs_obj_get_uint32(this, "pin", &pin);
 
     if (pin < ARC_AIO_MIN || pin > ARC_AIO_MAX) {
         PRINT("PIN: #%lu\n", pin);
@@ -268,41 +268,41 @@ static jerry_value_t zjs_aio_pin_read(const jerry_value_t function_obj_val,
     return jerry_create_number(value);
 }
 
-static jerry_value_t zjs_aio_pin_abort(const jerry_value_t function_obj_val,
-                                       const jerry_value_t this_val,
-                                       const jerry_value_t args_p[],
-                                       const jerry_length_t args_cnt)
+static jerry_value_t zjs_aio_pin_abort(const jerry_value_t function_obj,
+                                       const jerry_value_t this,
+                                       const jerry_value_t argv[],
+                                       const jerry_length_t argc)
 {
     // NO-OP
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_aio_pin_close(const jerry_value_t function_obj_val,
-                                       const jerry_value_t this_val,
-                                       const jerry_value_t args_p[],
-                                       const jerry_length_t args_cnt)
+static jerry_value_t zjs_aio_pin_close(const jerry_value_t function_obj,
+                                       const jerry_value_t this,
+                                       const jerry_value_t argv[],
+                                       const jerry_length_t argc)
 {
     // NO-OP
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_aio_pin_on(const jerry_value_t function_obj_val,
-                                    const jerry_value_t this_val,
-                                    const jerry_value_t args_p[],
-                                    const jerry_length_t args_cnt)
+static jerry_value_t zjs_aio_pin_on(const jerry_value_t function_obj,
+                                    const jerry_value_t this,
+                                    const jerry_value_t argv[],
+                                    const jerry_length_t argc)
 {
-    if (args_cnt < 2 ||
-        !jerry_value_is_string(args_p[0]) ||
-        (!jerry_value_is_object(args_p[1]) &&
-         !jerry_value_is_null(args_p[1]))) {
+    if (argc < 2 ||
+        !jerry_value_is_string(argv[0]) ||
+        (!jerry_value_is_object(argv[1]) &&
+         !jerry_value_is_null(argv[1]))) {
         return zjs_error("zjs_aio_pin_on: invalid argument");
     }
 
     uint32_t pin;
-    zjs_obj_get_uint32(this_val, "pin", &pin);
+    zjs_obj_get_uint32(this, "pin", &pin);
 
     char event[MAX_TYPE_LEN];
-    jerry_value_t arg = args_p[0];
+    jerry_value_t arg = argv[0];
     jerry_size_t sz = jerry_get_string_size(arg);
     if (sz >= MAX_TYPE_LEN)
         return zjs_error("zjs_aio_pin_on: event string too long");
@@ -317,13 +317,13 @@ static jerry_value_t zjs_aio_pin_on(const jerry_value_t function_obj_val,
     if (!item)
         return zjs_error("zjs_aio_pin_on: callback item not available");
 
-    item->pin_obj = this_val;
-    item->zjs_cb.js_callback = jerry_acquire_value(args_p[1]);
+    item->pin_obj = this;
+    item->zjs_cb.js_callback = jerry_acquire_value(argv[1]);
     item->zjs_cb.call_function = zjs_aio_emit_event;
     memcpy(item->event_type, event, len + 1);
 
     if (!strcmp(event, "change")) {
-        if (jerry_value_is_object(args_p[1])) {
+        if (jerry_value_is_object(argv[1])) {
             zjs_aio_ipm_send_async(TYPE_AIO_PIN_SUBSCRIBE, pin, 0);
         } else {
             zjs_aio_ipm_send_async(TYPE_AIO_PIN_UNSUBSCRIBE, pin, 0);
@@ -334,17 +334,17 @@ static jerry_value_t zjs_aio_pin_on(const jerry_value_t function_obj_val,
 }
 
 // Asynchronous Operations
-static jerry_value_t zjs_aio_pin_read_async(const jerry_value_t function_obj_val,
-                                            const jerry_value_t this_val,
-                                            const jerry_value_t args_p[],
-                                            const jerry_length_t args_cnt)
+static jerry_value_t zjs_aio_pin_read_async(const jerry_value_t function_obj,
+                                            const jerry_value_t this,
+                                            const jerry_value_t argv[],
+                                            const jerry_length_t argc)
 {
-    if (args_cnt < 1 || !jerry_value_is_function(args_p[0]))
+    if (argc < 1 || !jerry_value_is_function(argv[0]))
         return zjs_error("zjs_aio_pin_read_async: invalid argument");
 
     uint32_t device, pin;
-    zjs_obj_get_uint32(this_val, "device", &device);
-    zjs_obj_get_uint32(this_val, "pin", &pin);
+    zjs_obj_get_uint32(this, "device", &device);
+    zjs_obj_get_uint32(this, "pin", &pin);
 
     struct zjs_cb_list_item *item = zjs_aio_get_callback_item(pin, NULL);
     if (!item) {
@@ -354,8 +354,8 @@ static jerry_value_t zjs_aio_pin_read_async(const jerry_value_t function_obj_val
     if (!item)
         return zjs_error("zjs_aio_pin_read_async: callback item not available");
 
-    item->pin_obj = this_val;
-    item->zjs_cb.js_callback = jerry_acquire_value(args_p[0]);
+    item->pin_obj = this;
+    item->zjs_cb.js_callback = jerry_acquire_value(argv[0]);
     item->zjs_cb.call_function = zjs_aio_call_function;
 
     // send IPM message to the ARC side and wait for reponse
@@ -363,15 +363,15 @@ static jerry_value_t zjs_aio_pin_read_async(const jerry_value_t function_obj_val
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_aio_open(const jerry_value_t function_obj_val,
-                                  const jerry_value_t this_val,
-                                  const jerry_value_t args_p[],
-                                  const jerry_length_t args_cnt)
+static jerry_value_t zjs_aio_open(const jerry_value_t function_obj,
+                                  const jerry_value_t this,
+                                  const jerry_value_t argv[],
+                                  const jerry_length_t argc)
 {
-    if (args_cnt < 1 || !jerry_value_is_object(args_p[0]))
+    if (argc < 1 || !jerry_value_is_object(argv[0]))
         return zjs_error("zjs_aio_open: invalid argument");
 
-    jerry_value_t data = args_p[0];
+    jerry_value_t data = argv[0];
 
     uint32_t device;
     if (!zjs_obj_get_uint32(data, "device", &device))

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -189,17 +189,17 @@ void zjs_service_callbacks(void)
         if (cb_map[i]->signal) {
             cb_map[i]->signal = 0;
             if (cb_map[i]->type == CALLBACK_TYPE_JS && jerry_value_is_function(cb_map[i]->js->js_func)) {
-                uint32_t args_cnt = 0;
+                uint32_t argc = 0;
                 jerry_value_t ret_val;
                 jerry_value_t* args = NULL;
 
                 if (cb_map[i]->js->pre) {
-                    args = cb_map[i]->js->pre(cb_map[i]->js->handle, &args_cnt);
+                    args = cb_map[i]->js->pre(cb_map[i]->js->handle, &argc);
                 }
 
-                DBG_PRINT("[callbacks] zjs_service_callbacks(): Calling callback id %u with %u args\n", cb_map[i]->js->id, args_cnt);
+                DBG_PRINT("[callbacks] zjs_service_callbacks(): Calling callback id %u with %u args\n", cb_map[i]->js->id, argc);
                 // TODO: Use 'this' in callback module
-                jerry_call_function(cb_map[i]->js->js_func, ZJS_UNDEFINED, args, args_cnt);
+                jerry_call_function(cb_map[i]->js->js_func, ZJS_UNDEFINED, args, argc);
                 if (cb_map[i]->js->post) {
                     cb_map[i]->js->post(cb_map[i]->js->handle, &ret_val);
                 }

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -11,11 +11,11 @@
  * the function arguments for the JS function.
  *
  * @param handle        Module specific handle
- * @param args_cnt      Number of arguments in the returned array
+ * @param argc          Number of arguments in the returned array
  *
  * @return              Pointer to array of jerry_value_t's
  */
-typedef jerry_value_t* (*zjs_pre_callback_func)(void* handle, uint32_t* args_cnt);
+typedef jerry_value_t* (*zjs_pre_callback_func)(void* handle, uint32_t* argc);
 
 /*
  * Function that will be called AFTER the JS function is called.
@@ -50,7 +50,9 @@ void zjs_init_callbacks(void);
  *
  * @return              ID associated with this callback, use this ID to reference this CB
  */
-int32_t zjs_add_callback(jerry_value_t js_func, void* handle, zjs_pre_callback_func pre, zjs_post_callback_func post);
+int32_t zjs_add_callback(jerry_value_t js_func, void* handle,
+                         zjs_pre_callback_func pre,
+                         zjs_post_callback_func post);
 
 /*
  * Change a callbacks JS function

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -97,20 +97,20 @@ static struct gpio_handle* new_gpio_handle(void)
     return handle;
 }
 
-static jerry_value_t zjs_gpio_pin_read(const jerry_value_t function_obj_val,
-                                       const jerry_value_t this_val,
-                                       const jerry_value_t args_p[],
-                                       const jerry_length_t args_cnt)
+static jerry_value_t zjs_gpio_pin_read(const jerry_value_t function_obj,
+                                       const jerry_value_t this,
+                                       const jerry_value_t argv[],
+                                       const jerry_length_t argc)
 {
-    // requires: this_val is a GPIOPin object from zjs_gpio_open, takes no args
+    // requires: this is a GPIOPin object from zjs_gpio_open, takes no args
     //  effects: reads a logical value from the pin and returns it in ret_val_p
     uint32_t pin;
-    zjs_obj_get_uint32(this_val, "pin", &pin);
+    zjs_obj_get_uint32(this, "pin", &pin);
     int devnum, newpin;
     zjs_gpio_convert_pin(pin, &devnum, &newpin);
 
     bool activeLow = false;
-    zjs_obj_get_boolean(this_val, "activeLow", &activeLow);
+    zjs_obj_get_boolean(this, "activeLow", &activeLow);
 
     uint32_t value;
     int rval = gpio_pin_read(zjs_gpio_dev[devnum], newpin, &value);
@@ -126,26 +126,26 @@ static jerry_value_t zjs_gpio_pin_read(const jerry_value_t function_obj_val,
     return jerry_create_boolean(logical);
 }
 
-static jerry_value_t zjs_gpio_pin_write(const jerry_value_t function_obj_val,
-                                        const jerry_value_t this_val,
-                                        const jerry_value_t args_p[],
-                                        const jerry_length_t args_cnt)
+static jerry_value_t zjs_gpio_pin_write(const jerry_value_t function_obj,
+                                        const jerry_value_t this,
+                                        const jerry_value_t argv[],
+                                        const jerry_length_t argc)
 {
-    // requires: this_val is a GPIOPin object from zjs_gpio_open, takes one arg,
+    // requires: this is a GPIOPin object from zjs_gpio_open, takes one arg,
     //             the logical boolean value to set to the pin (true = active)
     //  effects: writes the logical value to the pin
-    if (args_cnt < 1 || !jerry_value_is_boolean(args_p[0]))
+    if (argc < 1 || !jerry_value_is_boolean(argv[0]))
         return zjs_error("zjs_gpio_pin_write: invalid argument");
 
-    bool logical = jerry_get_boolean_value(args_p[0]);
+    bool logical = jerry_get_boolean_value(argv[0]);
 
     uint32_t pin;
-    zjs_obj_get_uint32(this_val, "pin", &pin);
+    zjs_obj_get_uint32(this, "pin", &pin);
     int devnum, newpin;
     zjs_gpio_convert_pin(pin, &devnum, &newpin);
 
     bool activeLow = false;
-    zjs_obj_get_boolean(this_val, "activeLow", &activeLow);
+    zjs_obj_get_boolean(this, "activeLow", &activeLow);
 
     uint32_t value = 0;
     if ((logical && !activeLow) || (!logical && activeLow))
@@ -159,13 +159,13 @@ static jerry_value_t zjs_gpio_pin_write(const jerry_value_t function_obj_val,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_gpio_pin_close(const jerry_value_t function_obj_p,
-                                        const jerry_value_t this_val,
-                                        const jerry_value_t args_p[],
-                                        const jerry_length_t args_cnt)
+static jerry_value_t zjs_gpio_pin_close(const jerry_value_t function_obj,
+                                        const jerry_value_t this,
+                                        const jerry_value_t argv[],
+                                        const jerry_length_t argc)
 {
     uintptr_t ptr;
-    if (jerry_get_object_native_handle(this_val, &ptr)) {
+    if (jerry_get_object_native_handle(this, &ptr)) {
         struct gpio_handle* handle = (struct gpio_handle*)ptr;
         if (handle) {
             zjs_remove_callback(handle->callbackId);
@@ -174,7 +174,7 @@ static jerry_value_t zjs_gpio_pin_close(const jerry_value_t function_obj_p,
             }
 
             uint32_t pin;
-            zjs_obj_get_uint32(this_val, "pin", &pin);
+            zjs_obj_get_uint32(this, "pin", &pin);
             int devnum, newpin;
             zjs_gpio_convert_pin(pin, &devnum, &newpin);
 
@@ -197,20 +197,20 @@ static void post_open_promise(void* h)
     }
 }
 
-static jerry_value_t zjs_gpio_open(const jerry_value_t function_obj_val,
-                                   const jerry_value_t this_val,
-                                   const jerry_value_t args_p[],
-                                   const jerry_length_t args_cnt,
+static jerry_value_t zjs_gpio_open(const jerry_value_t function_obj,
+                                   const jerry_value_t this,
+                                   const jerry_value_t argv[],
+                                   const jerry_length_t argc,
                                    bool async)
 {
     // requires: arg 0 is an object with these members: pin (int), direction
     //             (defaults to "out"), activeLow (defaults to false),
     //             edge (defaults to "any"), pull (default to undefined)
-    if (args_cnt < 1 || !jerry_value_is_object(args_p[0]))
+    if (argc < 1 || !jerry_value_is_object(argv[0]))
         return zjs_error("zjs_gpio_open: invalid argument");
 
     // data input object
-    jerry_value_t data = args_p[0];
+    jerry_value_t data = argv[0];
 
     uint32_t pin;
     if (!zjs_obj_get_uint32(data, "pin", &pin))
@@ -343,20 +343,20 @@ static jerry_value_t zjs_gpio_open(const jerry_value_t function_obj_val,
     return pinobj;
 }
 
-static jerry_value_t zjs_gpio_open_sync(const jerry_value_t function_obj_val,
-                                        const jerry_value_t this_val,
-                                        const jerry_value_t args_p[],
-                                        const jerry_length_t args_cnt)
+static jerry_value_t zjs_gpio_open_sync(const jerry_value_t function_obj,
+                                        const jerry_value_t this,
+                                        const jerry_value_t argv[],
+                                        const jerry_length_t argc)
 {
-    return zjs_gpio_open(function_obj_val, this_val, args_p, args_cnt, false);
+    return zjs_gpio_open(function_obj, this, argv, argc, false);
 }
 
-static jerry_value_t zjs_gpio_open_async(const jerry_value_t function_obj_val,
-                                         const jerry_value_t this_val,
-                                         const jerry_value_t args_p[],
-                                         const jerry_length_t args_cnt)
+static jerry_value_t zjs_gpio_open_async(const jerry_value_t function_obj,
+                                         const jerry_value_t this,
+                                         const jerry_value_t argv[],
+                                         const jerry_length_t argc)
 {
-    return zjs_gpio_open(function_obj_val, this_val, args_p, args_cnt, true);
+    return zjs_gpio_open(function_obj, this, argv, argc, true);
 }
 
 jerry_value_t zjs_gpio_init()

--- a/src/zjs_grove_lcd.c
+++ b/src/zjs_grove_lcd.c
@@ -111,17 +111,17 @@ static void ipm_msg_receive_callback(void *context, uint32_t id, volatile void *
     }
 }
 
-static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj_val,
-                                    const jerry_value_t this_val,
-                                    const jerry_value_t args_p[],
-                                    const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
+                                    const jerry_value_t this,
+                                    const jerry_value_t argv[],
+                                    const jerry_length_t argc)
 {
-    if (args_cnt < 1 || !jerry_value_is_string(args_p[0])) {
+    if (argc < 1 || !jerry_value_is_string(argv[0])) {
         PRINT("zjs_glcd_print: invalid argument\n");
         return zjs_error("zjs_glcd_print: invalid argument");
     }
 
-    jerry_size_t sz = jerry_get_string_size(args_p[0]);
+    jerry_size_t sz = jerry_get_string_size(argv[0]);
 
     char *buffer = task_malloc(sz+1);
     if (!buffer) {
@@ -129,7 +129,7 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj_val,
         return zjs_error("cannot allocate buffer");
     }
 
-    int len = jerry_string_to_char_buffer(args_p[0],
+    int len = jerry_string_to_char_buffer(argv[0],
                                           (jerry_char_t *)buffer,
                                           sz);
     buffer[len] = '\0';
@@ -145,10 +145,10 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj_val,
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_clear(const jerry_value_t function_obj_val,
-                                    const jerry_value_t this_val,
-                                    const jerry_value_t args_p[],
-                                    const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_clear(const jerry_value_t function_obj,
+                                    const jerry_value_t this,
+                                    const jerry_value_t argv[],
+                                    const jerry_length_t argc)
 {
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();
@@ -160,94 +160,94 @@ static jerry_value_t zjs_glcd_clear(const jerry_value_t function_obj_val,
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_set_cursor_pos(const jerry_value_t function_obj_val,
-                                             const jerry_value_t this_val,
-                                             const jerry_value_t args_p[],
-                                             const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_set_cursor_pos(const jerry_value_t function_obj,
+                                             const jerry_value_t this,
+                                             const jerry_value_t argv[],
+                                             const jerry_length_t argc)
 {
-    if (args_cnt != 2 ||
-        !jerry_value_is_number(args_p[0]) ||
-        !jerry_value_is_number(args_p[1])) {
+    if (argc != 2 ||
+        !jerry_value_is_number(argv[0]) ||
+        !jerry_value_is_number(argv[1])) {
         return zjs_error("zjs_glcd_set_cursor_pos: invalid argument");
     }
 
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();
     send->type = TYPE_GLCD_SET_CURSOR_POS;
-    send->data.glcd.col = (uint8_t)jerry_get_number_value(args_p[0]);
-    send->data.glcd.row = (uint8_t)jerry_get_number_value(args_p[1]);
+    send->data.glcd.col = (uint8_t)jerry_get_number_value(argv[0]);
+    send->data.glcd.row = (uint8_t)jerry_get_number_value(argv[1]);
 
     jerry_value_t result = zjs_glcd_call_remote_function(send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_select_color(const jerry_value_t function_obj_val,
-                                           const jerry_value_t this_val,
-                                           const jerry_value_t args_p[],
-                                           const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_select_color(const jerry_value_t function_obj,
+                                           const jerry_value_t this,
+                                           const jerry_value_t argv[],
+                                           const jerry_length_t argc)
 {
-    if (args_cnt != 1 || !jerry_value_is_number(args_p[0])) {
+    if (argc != 1 || !jerry_value_is_number(argv[0])) {
         return zjs_error("zjs_glcd_select_color: invalid argument");
     }
 
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();
     send->type = TYPE_GLCD_SELECT_COLOR;
-    send->data.glcd.value = (uint8_t)jerry_get_number_value(args_p[0]);
+    send->data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
 
     jerry_value_t result = zjs_glcd_call_remote_function(send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_set_color(const jerry_value_t function_obj_val,
-                                        const jerry_value_t this_val,
-                                        const jerry_value_t args_p[],
-                                        const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_set_color(const jerry_value_t function_obj,
+                                        const jerry_value_t this,
+                                        const jerry_value_t argv[],
+                                        const jerry_length_t argc)
 {
-    if (args_cnt != 3 ||
-        !jerry_value_is_number(args_p[0]) ||
-        !jerry_value_is_number(args_p[1]) ||
-        !jerry_value_is_number(args_p[2])) {
+    if (argc != 3 ||
+        !jerry_value_is_number(argv[0]) ||
+        !jerry_value_is_number(argv[1]) ||
+        !jerry_value_is_number(argv[2])) {
         return zjs_error("zjs_glcd_set_color: invalid argument");
     }
 
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();
     send->type = TYPE_GLCD_SET_COLOR;
-    send->data.glcd.color_r = (uint8_t)jerry_get_number_value(args_p[0]);
-    send->data.glcd.color_g = (uint8_t)jerry_get_number_value(args_p[1]);
-    send->data.glcd.color_b = (uint8_t)jerry_get_number_value(args_p[2]);
+    send->data.glcd.color_r = (uint8_t)jerry_get_number_value(argv[0]);
+    send->data.glcd.color_g = (uint8_t)jerry_get_number_value(argv[1]);
+    send->data.glcd.color_b = (uint8_t)jerry_get_number_value(argv[2]);
 
     jerry_value_t result = zjs_glcd_call_remote_function(send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_set_function(const jerry_value_t function_obj_val,
-                                           const jerry_value_t this_val,
-                                           const jerry_value_t args_p[],
-                                           const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_set_function(const jerry_value_t function_obj,
+                                           const jerry_value_t this,
+                                           const jerry_value_t argv[],
+                                           const jerry_length_t argc)
 {
-    if (args_cnt != 1 || !jerry_value_is_number(args_p[0])) {
+    if (argc != 1 || !jerry_value_is_number(argv[0])) {
         return zjs_error("zjs_glcd_set_function: invalid argument");
     }
 
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();
     send->type = TYPE_GLCD_SET_FUNCTION;
-    send->data.glcd.value = (uint8_t)jerry_get_number_value(args_p[0]);
+    send->data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
 
     jerry_value_t result = zjs_glcd_call_remote_function(send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_get_function(const jerry_value_t function_obj_val,
-                                           const jerry_value_t this_val,
-                                           const jerry_value_t args_p[],
-                                           const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_get_function(const jerry_value_t function_obj,
+                                           const jerry_value_t this,
+                                           const jerry_value_t argv[],
+                                           const jerry_length_t argc)
 {
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();
@@ -257,29 +257,29 @@ static jerry_value_t zjs_glcd_get_function(const jerry_value_t function_obj_val,
     return zjs_glcd_call_remote_function(send);
 }
 
-static jerry_value_t zjs_glcd_set_display_state(const jerry_value_t function_obj_val,
-                                                const jerry_value_t this_val,
-                                                const jerry_value_t args_p[],
-                                                const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_set_display_state(const jerry_value_t function_obj,
+                                                const jerry_value_t this,
+                                                const jerry_value_t argv[],
+                                                const jerry_length_t argc)
 {
-    if (args_cnt != 1 || !jerry_value_is_number(args_p[0])) {
+    if (argc != 1 || !jerry_value_is_number(argv[0])) {
         return zjs_error("zjs_glcd_set_display_state: invalid argument");
     }
 
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();
     send->type = TYPE_GLCD_SET_DISPLAY_STATE;
-    send->data.glcd.value = (uint8_t)jerry_get_number_value(args_p[0]);
+    send->data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
 
     jerry_value_t result = zjs_glcd_call_remote_function(send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_get_display_state(const jerry_value_t function_obj_val,
-                                                const jerry_value_t this_val,
-                                                const jerry_value_t args_p[],
-                                                const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_get_display_state(const jerry_value_t function_obj,
+                                                const jerry_value_t this,
+                                                const jerry_value_t argv[],
+                                                const jerry_length_t argc)
 {
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();
@@ -289,29 +289,29 @@ static jerry_value_t zjs_glcd_get_display_state(const jerry_value_t function_obj
     return zjs_glcd_call_remote_function(send);
 }
 
-static jerry_value_t zjs_glcd_set_input_state(const jerry_value_t function_obj_val,
-                                              const jerry_value_t this_val,
-                                              const jerry_value_t args_p[],
-                                              const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_set_input_state(const jerry_value_t function_obj,
+                                              const jerry_value_t this,
+                                              const jerry_value_t argv[],
+                                              const jerry_length_t argc)
 {
-    if (args_cnt != 1 || !jerry_value_is_number(args_p[0])) {
+    if (argc != 1 || !jerry_value_is_number(argv[0])) {
         return zjs_error("zjs_glcd_set_input_state: invalid argument");
     }
 
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();
     send->type = TYPE_GLCD_SET_INPUT_STATE;
-    send->data.glcd.value = (uint8_t)jerry_get_number_value(args_p[0]);
+    send->data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
 
     jerry_value_t result = zjs_glcd_call_remote_function(send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_get_input_state(const jerry_value_t function_obj_val,
-                                              const jerry_value_t this_val,
-                                              const jerry_value_t args_p[],
-                                              const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_get_input_state(const jerry_value_t function_obj,
+                                              const jerry_value_t this,
+                                              const jerry_value_t argv[],
+                                              const jerry_length_t argc)
 {
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();
@@ -321,10 +321,10 @@ static jerry_value_t zjs_glcd_get_input_state(const jerry_value_t function_obj_v
     return zjs_glcd_call_remote_function(send);
 }
 
-static jerry_value_t zjs_glcd_init(const jerry_value_t function_obj_val,
-                                   const jerry_value_t this_val,
-                                   const jerry_value_t args_p[],
-                                   const jerry_length_t args_cnt)
+static jerry_value_t zjs_glcd_init(const jerry_value_t function_obj,
+                                   const jerry_value_t this,
+                                   const jerry_value_t argv[],
+                                   const jerry_length_t argc)
 {
     // send IPM message to the ARC side
     struct zjs_ipm_message* send = zjs_glcd_alloc_msg();

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -85,39 +85,39 @@ static void ipm_msg_receive_callback(void *context, uint32_t id, volatile void *
     }
 }
 
-static jerry_value_t zjs_i2c_read(const jerry_value_t function_obj_val,
-                                  const jerry_value_t this_val,
-                                  const jerry_value_t args_p[],
-                                  const jerry_length_t args_cnt)
+static jerry_value_t zjs_i2c_read(const jerry_value_t function_obj,
+                                  const jerry_value_t this,
+                                  const jerry_value_t argv[],
+                                  const jerry_length_t argc)
 {
     // Not implemented yet
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj_val,
-                                   const jerry_value_t this_val,
-                                   const jerry_value_t args_p[],
-                                   const jerry_length_t args_cnt)
+static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj,
+                                   const jerry_value_t this,
+                                   const jerry_value_t argv[],
+                                   const jerry_length_t argc)
 {
-    if (args_cnt < 2 || !jerry_value_is_object(args_p[0])) {
+    if (argc < 2 || !jerry_value_is_object(argv[0])) {
         return zjs_error("zjs_i2c_write: missing arguments");
     }
 
-    if (!jerry_value_is_object(args_p[1])) {
+    if (!jerry_value_is_object(argv[1])) {
         return zjs_error("zjs_i2c_write: message buffer is invalid");
     }
 
     uint32_t bus;
-    zjs_obj_get_uint32(this_val, "bus", &bus);
+    zjs_obj_get_uint32(this, "bus", &bus);
 
-    jerry_value_t jerryData = args_p[0];
+    jerry_value_t jerryData = argv[0];
 
     uint32_t length;
     if (!zjs_obj_get_uint32(jerryData, "length", &length)) {
         return zjs_error("zjs_i2c_write: missing required field (length)");
     }
 
-    struct zjs_buffer_t *dataBuf = zjs_buffer_find(args_p[1]);
+    struct zjs_buffer_t *dataBuf = zjs_buffer_find(argv[1]);
 
     if (!dataBuf) {
         return zjs_error("zjs_i2c_write:  missing data buffer");
@@ -155,35 +155,35 @@ static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj_val,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_i2c_abort(const jerry_value_t function_obj_val,
-                                   const jerry_value_t this_val,
-                                   const jerry_value_t args_p[],
-                                   const jerry_length_t args_cnt)
+static jerry_value_t zjs_i2c_abort(const jerry_value_t function_obj,
+                                   const jerry_value_t this,
+                                   const jerry_value_t argv[],
+                                   const jerry_length_t argc)
 {
     // Not implemented yet
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_i2c_close(const jerry_value_t function_obj_val,
-                                   const jerry_value_t this_val,
-                                   const jerry_value_t args_p[],
-                                   const jerry_length_t args_cnt)
+static jerry_value_t zjs_i2c_close(const jerry_value_t function_obj,
+                                   const jerry_value_t this,
+                                   const jerry_value_t argv[],
+                                   const jerry_length_t argc)
 {
     // Not implemented yet
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj_val,
-                                  const jerry_value_t this_val,
-                                  const jerry_value_t args_p[],
-                                  const jerry_length_t args_cnt)
+static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
+                                  const jerry_value_t this,
+                                  const jerry_value_t argv[],
+                                  const jerry_length_t argc)
 {
 
-    if (args_cnt < 1 || !jerry_value_is_object(args_p[0])) {
+    if (argc < 1 || !jerry_value_is_object(argv[0])) {
         return zjs_error("zjs_i2c_open: invalid argument");
     }
 
-    jerry_value_t data = args_p[0];
+    jerry_value_t data = argv[0];
 
     uint32_t bus;
     if (!zjs_obj_get_uint32(data, "bus", &bus)) {

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -19,12 +19,12 @@ struct modItem {
 
 static struct modItem *modList;
 
-static jerry_value_t native_require_handler(const jerry_value_t function_obj_val,
-                                            const jerry_value_t this_val,
-                                            const jerry_value_t args_p[],
-                                            const jerry_length_t args_cnt)
+static jerry_value_t native_require_handler(const jerry_value_t function_obj,
+                                            const jerry_value_t this,
+                                            const jerry_value_t argv[],
+                                            const jerry_length_t argc)
 {
-    jerry_value_t arg = args_p[0];
+    jerry_value_t arg = argv[0];
     if (!jerry_value_is_string(arg)) {
         return zjs_error("native_require_handler: invalid argument");
     }
@@ -42,8 +42,8 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj_val
         struct modItem *t = modList;
         while (t) {
             if (!strcmp(t->name, module)) {
-                jerry_value_t obj_val = jerry_acquire_value(t->init());
-                return obj_val;
+                jerry_value_t obj = jerry_acquire_value(t->init());
+                return obj;
             }
             t = t->next;
         }

--- a/src/zjs_promise.h
+++ b/src/zjs_promise.h
@@ -21,24 +21,25 @@ typedef void (*zjs_post_promise_func)(void* handle);
  *
  * @return              ID to reference this promise
  */
-int32_t zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post, void* handle);
+int32_t zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post,
+                         void* handle);
 
 /*
  * Fulfill a promise
  *
  * @param id            ID returned from zjs_make_promise()
  * @param args          Array of args that will be given to then()
- * @param args_cnt      Number of arguments in args
+ * @param argc          Number of arguments in args
  */
-void zjs_fulfill_promise(int32_t id, jerry_value_t args[], uint32_t args_cnt);
+void zjs_fulfill_promise(int32_t id, jerry_value_t args[], uint32_t argc);
 
 /*
  * Reject a promise
  *
  * @param id            ID returned from zjs_make_promise()
  * @param args          Array of args that will be given to catch()
- * @param args_cnt      Number of arguments in args
+ * @param argc          Number of arguments in args
  */
-void zjs_reject_promise(int32_t id, jerry_value_t args[], uint32_t args_cnt);
+void zjs_reject_promise(int32_t id, jerry_value_t args[], uint32_t argc);
 
 #endif /* __zjs_promises_h__ */

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -50,10 +50,10 @@ void zjs_run_pending_callbacks()
 }
 #endif // ZJS_LINUX_BUILD
 
-void zjs_set_property(const jerry_value_t obj, const char *str_p,
+void zjs_set_property(const jerry_value_t obj, const char *str,
                       const jerry_value_t prop)
 {
-    jerry_value_t name = jerry_create_string((jerry_char_t *)str_p);
+    jerry_value_t name = jerry_create_string((jerry_char_t *)str);
     jerry_set_property(obj, name, prop);
     jerry_release_value(name);
 }

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -44,9 +44,9 @@ void zjs_queue_init();
 void zjs_queue_callback(struct zjs_callback *cb);
 void zjs_run_pending_callbacks();
 
-void zjs_set_property(const jerry_value_t obj, const char *str_p,
-                      const jerry_value_t prop_val);
-jerry_value_t zjs_get_property (const jerry_value_t obj, const char *str_p);
+void zjs_set_property(const jerry_value_t obj, const char *str,
+                      const jerry_value_t prop);
+jerry_value_t zjs_get_property (const jerry_value_t obj, const char *str);
 
 void zjs_obj_add_boolean(jerry_value_t obj, bool flag, const char *name);
 void zjs_obj_add_function(jerry_value_t obj, void *function, const char *name);


### PR DESCRIPTION
Also, remove all _p and _val endings from variable names where they
just referred to the type of the variable.

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
