### PR TITLE
[convert] Break build immediately when minify attempt fails

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -32,6 +32,11 @@ if which uglifyjs &> /dev/null; then
     else
         uglifyjs -nc -mt $INPUT > /tmp/gen.tmp
     fi
+    ERR=$?
+    if (($ERR > 0)); then
+        echo Error: Minification failed!
+        exit $ERR
+    fi
 else
     cat $INPUT > /tmp/gen.tmp
 fi


### PR DESCRIPTION
Before, it would silently fail and leave an empty string in script_gen[].

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
