### PR TITLE
[Security] Disable eval() by using strict mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -111,7 +111,7 @@ void main(int argc, char *argv[])
         }
     }
 
-    code_eval = jerry_parse((jerry_char_t *)script, len, false);
+    code_eval = jerry_parse((jerry_char_t *)script, len, true);
     if (jerry_value_has_error_flag(code_eval)) {
         PRINT("JerryScript: cannot parse javascript\n");
         return;


### PR DESCRIPTION
For security reasons, we should disable eval() in the JavaScript,
by calling jerry_parse() with strict_mode set to true, it will
disable eval() function.

Signed-off-by: Jimmy Huang jimmy.huang@intel.com
