### PR TITLE
[events] Fixed Makefile to compile out events by default

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -30,7 +30,7 @@ function check_for_require()
 
 check_for_require events
 if [ $? -eq 0 ]; then
-    >&2 echo Using module: GPIO
+    >&2 echo Using module: EVENTS
     MODULES+=" -DBUILD_MODULE_EVENTS"
 fi
 check_for_require gpio

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -14,8 +14,6 @@ ifeq ($(BOARD), qemu_x86)
 ccflags-y += -DQEMU_BUILD
 endif
 
-ccflags-y += -DBUILD_MODULE_EVENTS
-
 obj-y += main.o \
          zjs_ble.o \
          zjs_buffer.o \


### PR DESCRIPTION
- Events will only be compiled in if a module is using it

Signed-off-by: James Prestwood james.prestwood@intel.com
