### PR TITLE
[clang] Fix compiler warnings

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -27,7 +27,7 @@ JERRY_LIBS = 		-ljerry-core -lm
 
 JERRY_LIB_PATH = 	-L$(JERRY_BASE)/build/lib/
 
-LINUX_FLAGS = -std=gnu99
+LINUX_FLAGS = -std=gnu99 -Wpointer-sign
 
 LINUX_DEFINES = -DZJS_LINUX_BUILD -DBUILD_MODULE_EVENTS
 

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -69,7 +69,7 @@ void zjs_add_event_listener(jerry_value_t obj, const char* event, jerry_value_t 
     jerry_value_t id_prop = zjs_get_property(event_obj, "callback_id");
     if (jerry_value_is_number(id_prop)) {
         // If there already is an event object, get the callback ID
-        zjs_obj_get_uint32(event_obj, "callback_id", &callback_id);
+        zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     }
     callback_id = zjs_add_callback_list(listener, ev, pre_event, post_event, callback_id);
 
@@ -179,7 +179,7 @@ static jerry_value_t remove_listener(const jerry_value_t function_obj,
     jerry_value_t id_prop = zjs_get_property(event_obj, "callback_id");
     if (jerry_value_is_number(id_prop)) {
         // If there already is an event object, get the callback ID
-        zjs_obj_get_uint32(event_obj, "callback_id", &callback_id);
+        zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     } else {
         DBG_PRINT(("callback_id not found for '%s'\n", event));
         return ZJS_UNDEFINED;
@@ -225,7 +225,7 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
     jerry_value_t id_prop = zjs_get_property(event_obj, "callback_id");
     if (jerry_value_is_number(id_prop)) {
         // If there already is an event object, get the callback ID
-        zjs_obj_get_uint32(event_obj, "callback_id", &callback_id);
+        zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     } else {
         DBG_PRINT(("callback_id not found for '%s'\n", event));
         return ZJS_UNDEFINED;
@@ -233,7 +233,7 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
 
     zjs_remove_callback(callback_id);
 
-    jerry_value_t event_name_val = jerry_create_string(event);
+    jerry_value_t event_name_val = jerry_create_string((const jerry_char_t*)event);
     jerry_delete_property(ev->map, (const jerry_value_t)event_name_val);
     jerry_release_value(event_name_val);
 
@@ -353,7 +353,7 @@ static jerry_value_t get_listener_count(const jerry_value_t function_obj,
     jerry_value_t id_prop = zjs_get_property(event_obj, "callback_id");
     if (jerry_value_is_number(id_prop)) {
         // If there already is an event object, get the callback ID
-        zjs_obj_get_uint32(event_obj, "callback_id", &callback_id);
+        zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     } else {
         DBG_PRINT(("callback_id not found for '%s'\n", event));
         return ZJS_UNDEFINED;
@@ -397,7 +397,7 @@ static jerry_value_t get_listeners(const jerry_value_t function_obj,
     jerry_value_t id_prop = zjs_get_property(event_obj, "callback_id");
     if (jerry_value_is_number(id_prop)) {
         // If there already is an event object, get the callback ID
-        zjs_obj_get_uint32(event_obj, "callback_id", &callback_id);
+        zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     } else {
         DBG_PRINT(("callback_id not found for '%s'\n", event));
         return ZJS_UNDEFINED;
@@ -454,10 +454,8 @@ bool zjs_trigger_event(jerry_value_t obj,
         return false;
     }
 
-    zjs_obj_get_uint32(event_obj, "callback_id", &callback_id);
-    if (callback_id == -1) {
-        zjs_free(trigger);
-        DBG_PRINT(("callback_id not found\n"));
+    if (!zjs_obj_get_int32(event_obj, "callback_id", &callback_id)) {
+        DBG_PRINT("[event] zjs_trigger_event(): Error, callback_id not found\n");
         return false;
     }
 

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -68,6 +68,7 @@ bool zjs_obj_get_string(jerry_value_t obj, const char *name, char *buffer,
                         int len);
 bool zjs_obj_get_double(jerry_value_t obj, const char *name, double *num);
 bool zjs_obj_get_uint32(jerry_value_t obj, const char *name, uint32_t *num);
+bool zjs_obj_get_int32(jerry_value_t obj, const char *name, int32_t *num);
 
 bool zjs_hex_to_byte(char *buf, uint8_t *byte);
 


### PR DESCRIPTION
Fix the number of clang compiler errors which are all of the same type:

passing 'int32_t *' (aka 'int *') to parameter
      of type 'uint32_t *' (aka 'unsigned int *') converts between pointers to
      integer types with different sign [-Wpointer-sign]

Signed-off-by: Sakari Poussa sakari.poussa@intel.com
Signed-off-by: James Prestwood james.prestwood@intel.com
