### PR TITLE
[callbacks] Fixed bug in zjs_remove_callback()

### DIFF
--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -103,6 +103,22 @@ int32_t zjs_add_callback(jerry_value_t js_func, void* handle,
                          zjs_post_callback_func post);
 
 /*
+ * Add a JS callback that will only get called once. After it is called it will
+ * be automatically removed.
+ *
+ * @param js_func       JS function to be called (this could be native too)
+ * @param handle        Module specific handle, given to pre/post
+ * @param pre           Function called before the JS function (explained above)
+ * @param post          Function called after the JS function (explained above)
+ *
+ * @return              ID associated with this callback, use this ID to reference this CB
+ */
+int32_t zjs_add_callback_once(jerry_value_t js_func,
+                              void* handle,
+                              zjs_pre_callback_func pre,
+                              zjs_post_callback_func post);
+
+/*
  * Change a callbacks JS function
  *
  * @param id            ID of callback


### PR DESCRIPTION
- Removing a callback would cause the static cb_size variable to be
  decremented. If the callback being removed was not the last CB in
  the array, it would cause the last callback in the array to never
  get called again (until another callback was added, incrementing
  cb_size) since the service routine was a for loop from 0 to cb_size.
- Added new API, zjs_add_callback_once() which adds a callback that
  only gets called one time, then automatically gets removed.

Signed-off-by: James Prestwood james.prestwood@intel.com
