### PR TITLE
[modules] Include zjs_event.h in zjs_modules.c

### DIFF
--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 
 // ZJS includes
+#include "zjs_event.h"
 #include "zjs_modules.h"
 #include "zjs_util.h"
 


### PR DESCRIPTION
Signed-off-by: James Prestwood james.prestwood@intel.com
