### PR TITLE
[Scripts] Stop allocating MAX_SCRIPT_SIZE, only what's needed

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -53,7 +53,7 @@ fi
 
 printf "/* This file was auto-generated */\n\n" > $OUTPUT
 printf "#include \"zjs_common.h\"\n\n" >> $OUTPUT
-printf "const char script_gen[MAX_SCRIPT_SIZE] = \"" >> $OUTPUT
+printf "const char *script_gen = \"" >> $OUTPUT
 
 # No field separator, read whole file (IFS=),
 # no backslash escape (-r),

--- a/src/main.c
+++ b/src/main.c
@@ -23,7 +23,7 @@
 
 #include "zjs_ble.h"
 
-extern const char script_gen[];
+extern const char *script_gen;
 
 // native eval handler
 static jerry_value_t native_eval_handler(const jerry_value_t function_obj,


### PR DESCRIPTION
Thanks to Jimmy for pointing this out, it was wasted space in our images.

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
