### PR TITLE
[General] Added some features to promises/events/callbacks

### DIFF
--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -167,6 +167,16 @@ void zjs_signal_callback(int32_t id);
 int32_t zjs_add_c_callback(void* handle, zjs_c_callback_func callback);
 
 /*
+ * Call a callback immediately. This should only be used when absolutely needed
+ * and in a task context. If it is possible to use zjs_signal_callback(), use it.
+ * Using this function could result in a large recursion stack because it does
+ * not wait until the main loop to call the JS function.
+ *
+ * @param i             ID of callback
+ */
+void zjs_call_callback(int32_t i);
+
+/*
  * Service the callback module. Any callback's that have been signaled will
  * be serviced and the signal flag will be unset.
  */

--- a/src/zjs_event.h
+++ b/src/zjs_event.h
@@ -40,7 +40,31 @@ void zjs_add_event_listener(jerry_value_t obj, const char* event, jerry_value_t 
  *
  * @return              True if there were listeners
  */
-bool zjs_trigger_event(jerry_value_t obj, const char* event, jerry_value_t args[], uint32_t args_cnt, zjs_post_event post, void* handle);
+bool zjs_trigger_event(jerry_value_t obj,
+                       const char* event,
+                       jerry_value_t args[],
+                       uint32_t args_cnt,
+                       zjs_post_event post,
+                       void* handle);
+
+/*
+ * Call any registered event listeners immediately
+ *
+ * @param obj           Object that contains the event to be triggered
+ * @param event         Name of event
+ * @param args          Arguments to give to the event listener as parameters
+ * @param args_cnt      Number of arguments
+ * @param post          Function to be called after the event is triggered
+ * @param handle        A handle that is accessable in the 'post' call
+ *
+ * @return              True if there were listeners
+ */
+bool zjs_trigger_event_now(jerry_value_t obj,
+                           const char* event,
+                           jerry_value_t argv[],
+                           uint32_t argc,
+                           zjs_post_event post,
+                           void* h);
 
 /*
  * Initialize the event module

--- a/src/zjs_promise.h
+++ b/src/zjs_promise.h
@@ -18,28 +18,26 @@ typedef void (*zjs_post_promise_func)(void* handle);
  * @param obj           Object to make a promise
  * @param post          Function to be called when the promise has been fulfilled/rejected
  * @param handle        Handle passed to post function
- *
- * @return              ID to reference this promise
  */
-int32_t zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post,
+void zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post,
                          void* handle);
 
 /*
  * Fulfill a promise
  *
- * @param id            ID returned from zjs_make_promise()
+ * @param obj           Promise object
  * @param args          Array of args that will be given to then()
  * @param argc          Number of arguments in args
  */
-void zjs_fulfill_promise(int32_t id, jerry_value_t args[], uint32_t argc);
+void zjs_fulfill_promise(jerry_value_t obj, jerry_value_t args[], uint32_t argc);
 
 /*
  * Reject a promise
  *
- * @param id            ID returned from zjs_make_promise()
+ * @param obj           Promise object
  * @param args          Array of args that will be given to catch()
  * @param argc          Number of arguments in args
  */
-void zjs_reject_promise(int32_t id, jerry_value_t args[], uint32_t argc);
+void zjs_reject_promise(jerry_value_t obj, jerry_value_t args[], uint32_t argc);
 
 #endif /* __zjs_promises_h__ */


### PR DESCRIPTION
- Promises are now referenced with the object, not an ID
- Fixed linux build for promises (removed task_\* calls)
- Callbacks can be called immediately, not in the main loop. This should only
  be done if it is known that the scope is not in an ISR
- Events can be called immediately, not in the main loop.

Signed-off-by: James Prestwood james.prestwood@intel.com
