### PR TITLE
[pool] Changed zjs_malloc/zjs_free to use Zephyr pools instead of heap

### DIFF
--- a/prj.mdef.base
+++ b/prj.mdef.base
@@ -3,5 +3,3 @@
 % TASK NAME  PRIO ENTRY STACK GROUPS
 % ==================================
   TASK TASKA    7 main  2048 [EXE]
-
-HEAP_SIZE 5120

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -14,6 +14,14 @@ ifeq ($(BOARD), qemu_x86)
 ccflags-y += -DQEMU_BUILD
 endif
 
+#ifeq ($(MEM_STATS), on)
+#ccflags-y += -DPRINT_MALLOCS
+#endif
+#ifeq ($(MEM_STATS), full)
+#ccflags-y += -DPRINT_MALLOCS
+#ccflags-y += -DDUMP_MEM_STATS
+#endif
+
 obj-y += main.o \
          zjs_ble.o \
          zjs_buffer.o \

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,10 @@
 // JerryScript includes
 #include "jerry-api.h"
 
+#ifdef ZJS_POOL_CONFIG
+#include "zjs_pool.h"
+#endif
+
 // Platform agnostic modules/headers
 #include "zjs_buffer.h"
 #include "zjs_callbacks.h"
@@ -44,6 +48,13 @@ int main(int argc, char *argv[])
     jerry_value_t code_eval;
     jerry_value_t result;
     uint32_t len;
+
+#ifdef ZJS_POOL_CONFIG
+    zjs_init_mem_pools();
+#ifdef DUMP_MEM_STATS
+    zjs_print_pools();
+#endif
+#endif
 
     jerry_init(JERRY_INIT_EMPTY);
 

--- a/src/zjs_pool.c
+++ b/src/zjs_pool.c
@@ -1,0 +1,233 @@
+// Copyright (c) 2016, Intel Corporation.
+
+#ifdef ZJS_POOL_CONFIG
+#include <zephyr.h>
+
+#include <string.h>
+
+#include "zjs_common.h"
+#include "zjs_util.h"
+
+/*
+ * Overhead:
+ *
+ * pool_map_t:      block = 16 bytes
+ *                  total = 16 bytes
+ *
+ * pool_lookup_t:   size = 4 bytes
+ *                  pool_id = 4 bytes
+ *                  total = 8 bytes
+ *
+ * lookup:          sizeof(pool_lookup_t) * length(lookup)
+ *                  8 * 6
+ *                  = 48 bytes
+ *
+ * pointer_map:     sizeof(pool_map_t) * MAX_CONCURENT_POINTERS
+ *                  16 * 32
+ *                  = 512 bytes
+ *
+ * total overhead:  48 + 512
+ *                  = 560 bytes
+ *
+ *
+ * TODO: Find a better way to generate the pool sizes and max concurrent
+ *       pointers. There should be a way to choose the values based on a static
+ *       analysis of the script, looking at what modules are being used and how
+ *       many malloc's each does.
+ */
+
+typedef struct pool_map {
+    struct k_block block;
+#ifdef DUMP_MEM_STATS
+    uint32_t size;
+    uint32_t pool_size;
+#endif
+} pool_map_t;
+
+typedef struct pool_lookup {
+    uint32_t size;
+    uint32_t pool_id;
+} pool_lookup_t;
+
+static pool_lookup_t lookup[] = {
+    { 8,    POOL_8 },
+    { 16,   POOL_16 },
+    { 36,   POOL_36 },
+    { 64,   POOL_64 },
+    { 128,  POOL_128 },
+    { 256,  POOL_256 }
+};
+
+#define MAX_CONCURRENT_POINTERS  32
+
+static pool_map_t pointer_map[MAX_CONCURRENT_POINTERS];
+
+#define POOL_SIZE_TOO_SMALL     0xFFFFFFFF
+
+#ifdef DUMP_MEM_STATS
+static uint32_t mem_high_water = 0;
+static uint32_t mem_in_use = 0;
+static uint32_t pointers_used = 0;
+static uint32_t max_pointers_used = 0;
+static uint32_t max_waste = 0;
+
+void zjs_print_pools(void)
+{
+    int i;
+    uint32_t total_waste = 0;
+    PRINT("\nDumping pools:\n");
+    for (i = 0; i < (sizeof(lookup) / sizeof(lookup[0])); ++i) {
+        int j;
+        uint32_t cur_use = 0;
+        uint32_t cur_waste = 0;
+        uint32_t min_size = lookup[i].size;
+        uint32_t max_size = lookup[i].size;
+        PRINT("Pool size: %lu\n", lookup[i].size);
+        for (j = 0; j < MAX_CONCURRENT_POINTERS; ++j) {
+            if (pointer_map[j].block.pointer_to_data && pointer_map[j].pool_size == lookup[i].size) {
+                cur_use++;
+                cur_waste += lookup[i].size - pointer_map[j].block.req_size;
+                if (min_size > pointer_map[j].size) {
+                    min_size = pointer_map[j].size;
+                }
+                if (max_size < pointer_map[j].size) {
+                    max_size = pointer_map[j].size;
+                }
+            }
+        }
+        PRINT("\tBlocks Used: %lu, Memory Used: %lu, Memory Waste: %lu\n", cur_use, cur_use * lookup[i].size, cur_waste);
+        PRINT("\tMin Size: %lu, Max Size: %lu\n", min_size, max_size);
+        total_waste += cur_waste;
+    }
+    if (max_waste < total_waste) {
+        max_waste = total_waste;
+    }
+    PRINT("Memory Used: %lu, High Water: %lu\n", mem_in_use, mem_high_water);
+    PRINT("Memory Waste: %lu, Max Waste: %lu\n", total_waste, max_waste);
+    PRINT("Pointers Used: %lu, Max Used: %lu\n", pointers_used, max_pointers_used);
+}
+#else
+#define zjs_print_pools(void) do {} while (0);
+#endif
+
+void zjs_init_mem_pools(void)
+{
+    int i;
+    for (i = 0; i < MAX_CONCURRENT_POINTERS; ++i) {
+#ifdef DUMP_MEM_STATS
+        pointer_map[i].size = 0;
+#endif
+        pointer_map[i].block.pointer_to_data = NULL;
+    }
+}
+
+#ifdef DUMP_MEM_STATS
+static void add_pointer(struct k_block* block, uint32_t size, uint32_t pool_size)
+#else
+static void add_pointer(struct k_block* block)
+
+#endif
+{
+    int i;
+    for (i = 0; i < MAX_CONCURRENT_POINTERS; ++i) {
+        if (pointer_map[i].block.pointer_to_data == NULL) {
+            memcpy(&pointer_map[i].block, block, sizeof(struct k_block));
+#ifdef DUMP_MEM_STATS
+            pointer_map[i].size = size;
+            pointer_map[i].pool_size = pool_size;
+            mem_in_use += size;
+            if (mem_in_use > mem_high_water) {
+                mem_high_water = mem_in_use;
+            }
+#endif
+            return;
+        }
+    }
+}
+
+#ifdef DUMP_MEM_STATS
+static uint32_t lookup_pool(uint32_t size, uint32_t* pool_size)
+#else
+static uint32_t lookup_pool(uint32_t size)
+
+#endif
+{
+    int i;
+    for (i = 0; i < (sizeof(lookup) / sizeof(lookup[0])); ++i) {
+        if (size <= lookup[i].size) {
+#ifdef DUMP_MEM_STATS
+            *pool_size = lookup[i].size;
+#endif
+            return lookup[i].pool_id;
+        }
+    }
+    return POOL_SIZE_TOO_SMALL;
+}
+
+void* pool_malloc(uint32_t size)
+{
+    int ret;
+    struct k_block block;
+    uint32_t pool;
+#ifdef DUMP_MEM_STATS
+    uint32_t pool_size;
+    pool = lookup_pool(size, &pool_size);
+#else
+    pool = lookup_pool(size);
+#endif
+    if (pool == POOL_SIZE_TOO_SMALL) {
+        DBG_PRINT(("no pool size big enough for %lu bytes\n", size));
+        return NULL;
+    }
+    ret = task_mem_pool_alloc(&block, pool, size, TICKS_NONE);
+    if (ret != RC_OK) {
+        DBG_PRINT(("task_mem_pool_alloc() returned an error: %u\n", ret));
+        return NULL;
+    }
+#ifdef DUMP_MEM_STATS
+    add_pointer(&block, size, pool_size);
+    pointers_used++;
+    if (max_pointers_used < pointers_used) {
+        max_pointers_used = pointers_used;
+    }
+#else
+    add_pointer(&block);
+#endif
+#ifdef ZJS_TRACE_MALLOC
+#ifdef DUMP_MEM_STATS
+    PRINT("\tpool size=%lu\n", pool_size);
+#endif
+#endif
+
+    zjs_print_pools();
+
+    return block.pointer_to_data;
+}
+
+void pool_free(void* ptr)
+{
+    int i;
+    for (i = 0; i < MAX_CONCURRENT_POINTERS; ++i) {
+        if (pointer_map[i].block.pointer_to_data == ptr) {
+            struct k_block block;
+            memcpy(&block, &pointer_map[i].block, sizeof(struct k_block));
+#ifdef DUMP_MEM_STATS
+            mem_in_use -= pointer_map[i].size;
+            pointers_used--;
+#endif
+#ifdef ZJS_TRACE_MALLOC
+#ifdef DUMP_MEM_STATS
+            PRINT("\tpointer size=%lu bytes\n", pointer_map[i].size);
+#endif
+#endif
+            task_mem_pool_free(&block);
+            pointer_map[i].block.pointer_to_data = NULL;
+            zjs_print_pools();
+            return;
+        }
+    }
+#ifdef DUMP_MEM_STATS
+    zjs_print_pools();
+#endif
+}
+#endif

--- a/src/zjs_pool.h
+++ b/src/zjs_pool.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2016, Intel Corporation.
+
+#ifndef SRC_ZJS_POOL_H_
+#define SRC_ZJS_POOL_H_
+
+#ifdef ZJS_POOL_CONFIG
+void zjs_init_mem_pools(void);
+
+void* pool_malloc(uint32_t size);
+
+void pool_free(void* ptr);
+
+void zjs_print_pools(void);
+#endif // ZJS_POOL_CONFIG
+
+#endif /* SRC_ZJS_POOL_H_ */

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -7,6 +7,7 @@
 
 #include "jerry-api.h"
 #include "zjs_common.h"
+#include "zjs_pool.h"
 
 #define ZJS_UNDEFINED jerry_create_undefined()
 
@@ -23,6 +24,7 @@
 #define zjs_malloc(sz) malloc(sz)
 #define zjs_free(ptr) free((void *)ptr)
 #else
+#ifndef ZJS_POOL_CONFIG
 #ifdef ZJS_TRACE_MALLOC
 #include <zephyr.h>
 #define zjs_malloc(sz) ({void *zjs_ptr = task_malloc(sz); PRINT("%s:%d: allocating %lu bytes (%p)\n", __func__, __LINE__, (uint32_t)sz, zjs_ptr); zjs_ptr;})
@@ -32,6 +34,17 @@
 #define zjs_malloc(sz) task_malloc(sz)
 #define zjs_free(ptr) task_free(ptr)
 #endif  // ZJS_TRACE_MALLOC
+#else
+#ifdef ZJS_TRACE_MALLOC
+#include <zephyr.h>
+#define zjs_malloc(sz) ({void *zjs_ptr = pool_malloc(sz); PRINT("%s:%d: allocating %lu bytes (%p)\n", __func__, __LINE__, (uint32_t)sz, zjs_ptr); zjs_ptr;})
+#define zjs_free(ptr) (PRINT("%s:%d: freeing %p\n", __func__, __LINE__, ptr), pool_free(ptr))
+#else
+#include <zephyr.h>
+#define zjs_malloc(sz) pool_malloc(sz)
+#define zjs_free(ptr) pool_free(ptr)
+#endif  // ZJS_TRACE_MALLOC
+#endif  // ZJS_POOL_CONFIG
 #endif  // ZJS_LINUX_BUILD
 
 struct zjs_callback;


### PR DESCRIPTION
- This should save memory by allowing allocations to consume less memory
  than 80 bytes.
- Currently this is just a prototype

Signed-off-by: James Prestwood james.prestwood@intel.com
