### PR TITLE
[General] Modify DBG_PRINT to not require double parentheses

### DIFF
--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -57,11 +57,11 @@ static int32_t new_id(void)
         size_t size = sizeof(struct zjs_callback_map *) * cb_limit;
         struct zjs_callback_map** new_map = zjs_malloc(size);
         if (!new_map) {
-            DBG_PRINT(("error allocating space for new callback map\n"));
+            DBG_PRINT("error allocating space for new callback map\n");
             return -1;
         }
-        DBG_PRINT(("callback list size too small, increasing by %d\n",
-                CB_CHUNK_SIZE));
+        DBG_PRINT("callback list size too small, increasing by %d\n",
+                  CB_CHUNK_SIZE);
         memset(new_map, 0, size);
         memcpy(new_map, cb_map, sizeof(struct zjs_callback_map *) * cb_size);
         zjs_free(cb_map);
@@ -80,7 +80,7 @@ void zjs_init_callbacks(void)
             INITIAL_CALLBACK_SIZE;
         cb_map = (struct zjs_callback_map**)zjs_malloc(size);
         if (!cb_map) {
-            DBG_PRINT(("error allocating space for CB map\n"));
+            DBG_PRINT("error allocating space for CB map\n");
             return;
         }
         memset(cb_map, 0, size);
@@ -191,18 +191,18 @@ int32_t zjs_add_callback_list(jerry_value_t js_func,
             cb_map[id]->js->num_funcs++;
             return cb_map[id]->js->id;
         } else {
-            DBG_PRINT(("list handle was NULL\n"));
+            DBG_PRINT("list handle was NULL\n");
             return -1;
         }
     } else {
         struct zjs_callback_map* new_cb = zjs_malloc(sizeof(struct zjs_callback_map));
         if (!new_cb) {
-            DBG_PRINT(("error allocating space for new callback\n"));
+            DBG_PRINT("error allocating space for new callback\n");
             return -1;
         }
         new_cb->js = zjs_malloc(sizeof(struct zjs_callback_t));
         if (!new_cb->js) {
-            DBG_PRINT(("error allocating space for new callback\n"));
+            DBG_PRINT("error allocating space for new callback\n");
             zjs_free(new_cb);
             return -1;
         }
@@ -216,7 +216,7 @@ int32_t zjs_add_callback_list(jerry_value_t js_func,
         new_cb->js->num_funcs = 1;
         new_cb->js->func_list = zjs_malloc(sizeof(jerry_value_t) * CB_LIST_MULTIPLIER);
         if (!new_cb->js->func_list) {
-            DBG_PRINT(("could not allocate function list\n"));
+            DBG_PRINT("could not allocate function list\n");
             return -1;
         }
         new_cb->js->func_list[0] = jerry_acquire_value(js_func);
@@ -234,12 +234,12 @@ int32_t add_callback(jerry_value_t js_func,
 {
     struct zjs_callback_map* new_cb = zjs_malloc(sizeof(struct zjs_callback_map));
     if (!new_cb) {
-        DBG_PRINT(("error allocating space for new callback\n"));
+        DBG_PRINT("error allocating space for new callback\n");
         return -1;
     }
     new_cb->js = zjs_malloc(sizeof(struct zjs_callback_t));
     if (!new_cb->js) {
-        DBG_PRINT(("error allocating space for new callback\n"));
+        DBG_PRINT("error allocating space for new callback\n");
         zjs_free(new_cb);
         return -1;
     }
@@ -259,8 +259,8 @@ int32_t add_callback(jerry_value_t js_func,
     cb_map[new_cb->js->id] = new_cb;
     cb_size++;
 
-    DBG_PRINT(("adding new callback id %ld, js_func=%lu, once=%u\n",
-            new_cb->js->id, new_cb->js->js_func, once));
+    DBG_PRINT("adding new callback id %ld, js_func=%lu, once=%u\n",
+              new_cb->js->id, new_cb->js->js_func, once);
 
     return new_cb->js->id;
 }
@@ -300,7 +300,7 @@ void zjs_remove_callback(int32_t id)
         }
         zjs_free(cb_map[id]);
         cb_map[id] = NULL;
-        DBG_PRINT(("removing callback id %ld\n", id));
+        DBG_PRINT("removing callback id %ld\n", id);
     }
 }
 
@@ -309,9 +309,9 @@ void zjs_signal_callback(int32_t id)
     if (id != -1 && cb_map[id]) {
 #ifdef DEBUG_BUILD
         if (cb_map[id]->type == CALLBACK_TYPE_JS) {
-            DBG_PRINT(("signaling JS callback id %ld\n", id));
+            DBG_PRINT("signaling JS callback id %ld\n", id);
         } else {
-            DBG_PRINT(("signaling C callback id %ld\n", id));
+            DBG_PRINT("signaling C callback id %ld\n", id);
         }
 #endif
         cb_map[id]->signal = 1;
@@ -322,12 +322,12 @@ int32_t zjs_add_c_callback(void* handle, zjs_c_callback_func callback)
 {
     struct zjs_callback_map* new_cb = zjs_malloc(sizeof(struct zjs_callback_map));
     if (!new_cb) {
-        DBG_PRINT(("error allocating space for new callback\n"));
+        DBG_PRINT("error allocating space for new callback\n");
         return -1;
     }
     new_cb->c = zjs_malloc(sizeof(struct zjs_c_callback_t));
     if (!new_cb->c) {
-        DBG_PRINT(("error allocating space for new callback\n"));
+        DBG_PRINT("error allocating space for new callback\n");
         zjs_free(new_cb);
         return -1;
     }
@@ -341,7 +341,7 @@ int32_t zjs_add_c_callback(void* handle, zjs_c_callback_func callback)
     cb_map[new_cb->c->id] = new_cb;
     cb_size++;
 
-    DBG_PRINT(("adding new C callback id %ld\n", new_cb->c->id));
+    DBG_PRINT("adding new C callback id %ld\n", new_cb->c->id);
 
     return new_cb->c->id;
 }
@@ -387,7 +387,7 @@ void zjs_call_callback(int32_t i)
                 args = cb_map[i]->js->pre(cb_map[i]->js->handle, &argc);
             }
 
-            DBG_PRINT(("calling callback id %ld with %lu args\n", cb_map[i]->js->id, argc));
+            DBG_PRINT("calling callback id %ld with %lu args\n", cb_map[i]->js->id, argc);
             // TODO: Use 'this' in callback module
             jerry_call_function(cb_map[i]->js->js_func, ZJS_UNDEFINED, args, argc);
             if (cb_map[i]->js->post) {
@@ -406,7 +406,7 @@ void zjs_call_callback(int32_t i)
                 args = cb_map[i]->js->pre(cb_map[i]->js->handle, &argc);
             }
 
-            DBG_PRINT(("calling callback list id %ld with %lu args\n", cb_map[i]->js->id, argc));
+            DBG_PRINT("calling callback list id %ld with %lu args\n", cb_map[i]->js->id, argc);
 
             for (j = 0; j < cb_map[i]->js->num_funcs; ++j) {
                 jerry_call_function(cb_map[i]->js->func_list[j], ZJS_UNDEFINED, args, argc);
@@ -416,7 +416,7 @@ void zjs_call_callback(int32_t i)
             }
         }
     } else if (cb_map[i]->type == CALLBACK_TYPE_C && cb_map[i]->c->function) {
-        DBG_PRINT(("calling callback id %ld\n", cb_map[i]->c->id));
+        DBG_PRINT("calling callback id %ld\n", cb_map[i]->c->id);
         cb_map[i]->c->function(cb_map[i]->c->handle);
     }
 }

--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -4,18 +4,10 @@
 #define __zjs_common_h__
 
 // This file includes code common to both X86 and ARC
-#ifndef ZJS_LINUX_BUILD
-#if defined(CONFIG_STDOUT_CONSOLE)
+
 #include <stdio.h>
-#define PRINT           printf
-#else
-#include <misc/printk.h>
-#define PRINT           printk
-#endif
-#else
-#include <stdio.h>
-#define PRINT           printf
-#endif
+
+#define PRINT printf
 
 // TODO: We should instead have a macro that changes in debug vs. release build,
 // to save string space and instead print error codes or something for release.

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -53,11 +53,11 @@ void zjs_add_event_listener(jerry_value_t obj, const char* event, jerry_value_t 
 
     jerry_value_t event_emitter = zjs_get_property(obj, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
-        DBG_PRINT(("native handle not found\n"));
+        DBG_PRINT("native handle not found\n");
         return;
     }
     if (ev->num_events >= ev->max_listeners) {
-        DBG_PRINT(("max listeners reached\n"));
+        DBG_PRINT("max listeners reached\n");
         return;
     }
 
@@ -80,7 +80,7 @@ void zjs_add_event_listener(jerry_value_t obj, const char* event, jerry_value_t 
     // Add event object to master event listener
     zjs_set_property(ev->map, event, event_obj);
 
-    DBG_PRINT(("added listener, callback id = %ld\n", callback_id));
+    DBG_PRINT("added listener, callback id = %ld\n", callback_id);
 
     ev->num_events++;
 }
@@ -91,22 +91,22 @@ static jerry_value_t add_listener(const jerry_value_t function_obj,
                                   const jerry_length_t argc)
 {
     if (!jerry_value_is_string(argv[0])) {
-        DBG_PRINT(("first parameter must be event string\n"));
+        DBG_PRINT("first parameter must be event string\n");
         return ZJS_UNDEFINED;
     }
     if (!jerry_value_is_function(argv[1])) {
-        DBG_PRINT(("second parameter must be a listener function\n"));
+        DBG_PRINT("second parameter must be a listener function\n");
         return ZJS_UNDEFINED;
     }
     int sz = jerry_get_string_size(argv[0]);
     if (sz > ZJS_MAX_EVENT_NAME_SIZE) {
-        DBG_PRINT(("event name is too long\n"));
+        DBG_PRINT("event name is too long\n");
         return ZJS_UNDEFINED;
     }
     char name[sz];
     int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)name, sz);
     if (len != sz) {
-        DBG_PRINT(("size mismatch\n"));
+        DBG_PRINT("size mismatch\n");
         return ZJS_UNDEFINED;
     }
     name[len] = '\0';
@@ -122,14 +122,14 @@ static jerry_value_t emit_event(const jerry_value_t function_obj,
                                 const jerry_length_t argc)
 {
     if (!jerry_value_is_string(argv[0])) {
-        DBG_PRINT(("parameter is not a string\n"));
+        DBG_PRINT("parameter is not a string\n");
         return ZJS_UNDEFINED;
     }
     int sz = jerry_get_string_size(argv[0]);
     char event[sz];
     int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
     if (len != sz) {
-        DBG_PRINT(("size mismatch\n"));
+        DBG_PRINT("size mismatch\n");
         return ZJS_UNDEFINED;
     }
     event[len] = '\0';
@@ -151,22 +151,22 @@ static jerry_value_t remove_listener(const jerry_value_t function_obj,
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
-        DBG_PRINT(("native handle not found\n"));
+        DBG_PRINT("native handle not found\n");
         return ZJS_UNDEFINED;
     }
     if (!jerry_value_is_string(argv[0])) {
-        DBG_PRINT(("event name must be first parameter\n"));
+        DBG_PRINT("event name must be first parameter\n");
         return ZJS_UNDEFINED;
     }
     if (!jerry_value_is_function(argv[1])) {
-        DBG_PRINT(("event listener must be second parameter\n"));
+        DBG_PRINT("event listener must be second parameter\n");
         return ZJS_UNDEFINED;
     }
     int sz = jerry_get_string_size(argv[0]);
     char event[sz];
     int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
     if (len != sz) {
-        DBG_PRINT(("size mismatch\n"));
+        DBG_PRINT("size mismatch\n");
         return ZJS_UNDEFINED;
     }
     event[len] = '\0';
@@ -174,7 +174,7 @@ static jerry_value_t remove_listener(const jerry_value_t function_obj,
     // Event object to hold callback ID and eventually listener arguments
     jerry_value_t event_obj = zjs_get_property(ev->map, event);
     if (!jerry_value_is_object(event_obj)) {
-        DBG_PRINT(("event object not found for '%s'\n", event));
+        DBG_PRINT("event object not found for '%s'\n", event);
         return ZJS_UNDEFINED;
     }
 
@@ -184,7 +184,7 @@ static jerry_value_t remove_listener(const jerry_value_t function_obj,
         // If there already is an event object, get the callback ID
         zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     } else {
-        DBG_PRINT(("callback_id not found for '%s'\n", event));
+        DBG_PRINT("callback_id not found for '%s'\n", event);
         return ZJS_UNDEFINED;
     }
 
@@ -202,18 +202,18 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
-        DBG_PRINT(("native handle not found\n"));
+        DBG_PRINT("native handle not found\n");
         return ZJS_UNDEFINED;
     }
     if (!jerry_value_is_string(argv[0])) {
-        DBG_PRINT(("event name must be first parameter\n"));
+        DBG_PRINT("event name must be first parameter\n");
         return ZJS_UNDEFINED;
     }
     int sz = jerry_get_string_size(argv[0]);
     char event[sz];
     int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
     if (len != sz) {
-        DBG_PRINT(("size mismatch\n"));
+        DBG_PRINT("size mismatch\n");
         return ZJS_UNDEFINED;
     }
     event[len] = '\0';
@@ -221,7 +221,7 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
     // Event object to hold callback ID and eventually listener arguments
     jerry_value_t event_obj = zjs_get_property(ev->map, event);
     if (!jerry_value_is_object(event_obj)) {
-        DBG_PRINT(("event object not found for '%s'\n", event));
+        DBG_PRINT("event object not found for '%s'\n", event);
         return ZJS_UNDEFINED;
     }
 
@@ -231,7 +231,7 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
         // If there already is an event object, get the callback ID
         zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     } else {
-        DBG_PRINT(("callback_id not found for '%s'\n", event));
+        DBG_PRINT("callback_id not found for '%s'\n", event);
         return ZJS_UNDEFINED;
     }
 
@@ -266,7 +266,7 @@ static jerry_value_t get_event_names(const jerry_value_t function_obj,
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
-        DBG_PRINT(("native handle not found\n"));
+        DBG_PRINT("native handle not found\n");
         return ZJS_UNDEFINED;
     }
     names.idx = 0;
@@ -286,7 +286,7 @@ static jerry_value_t get_max_listeners(const jerry_value_t function_obj,
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
-        DBG_PRINT(("native handle not found\n"));
+        DBG_PRINT("native handle not found\n");
         return ZJS_UNDEFINED;
     }
     return jerry_create_number(ev->max_listeners);
@@ -301,11 +301,11 @@ static jerry_value_t set_max_listeners(const jerry_value_t function_obj,
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
-        DBG_PRINT(("native handle not found\n"));
+        DBG_PRINT("native handle not found\n");
         return ZJS_UNDEFINED;
     }
     if (!jerry_value_is_number(argv[0])) {
-        DBG_PRINT(("max listeners count must be first parameter\n"));
+        DBG_PRINT("max listeners count must be first parameter\n");
         return ZJS_UNDEFINED;
     }
     ev->max_listeners = (uint32_t)jerry_get_number_value(argv[0]);
@@ -334,18 +334,18 @@ static jerry_value_t get_listener_count(const jerry_value_t function_obj,
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
-        DBG_PRINT(("native handle not found\n"));
+        DBG_PRINT("native handle not found\n");
         return zjs_error("native handle not found");
     }
     if (!jerry_value_is_string(argv[0])) {
-        DBG_PRINT(("event name must be first parameter\n"));
+        DBG_PRINT("event name must be first parameter\n");
         return zjs_error("event name must be first parameter");
     }
     int sz = jerry_get_string_size(argv[0]);
     char event[sz];
     int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
     if (len != sz) {
-        DBG_PRINT(("size mismatch\n"));
+        DBG_PRINT("size mismatch\n");
         return zjs_error("string size mismatch");
     }
     event[len] = '\0';
@@ -353,7 +353,7 @@ static jerry_value_t get_listener_count(const jerry_value_t function_obj,
     // Event object to hold callback ID and eventually listener arguments
     jerry_value_t event_obj = zjs_get_property(ev->map, event);
     if (!jerry_value_is_object(event_obj)) {
-        DBG_PRINT(("event object not found for '%s'\n", event));
+        DBG_PRINT("event object not found for '%s'\n", event);
         return jerry_create_number(0);
     }
 
@@ -363,7 +363,7 @@ static jerry_value_t get_listener_count(const jerry_value_t function_obj,
         // If there already is an event object, get the callback ID
         zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     } else {
-        DBG_PRINT(("callback_id not found for '%s'\n", event));
+        DBG_PRINT("callback_id not found for '%s'\n", event);
         return jerry_create_number(0);
     }
 
@@ -379,18 +379,18 @@ static jerry_value_t get_listeners(const jerry_value_t function_obj,
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
-        DBG_PRINT(("native handle not found\n"));
+        DBG_PRINT("native handle not found\n");
         return ZJS_UNDEFINED;
     }
     if (!jerry_value_is_string(argv[0])) {
-        DBG_PRINT(("event name must be first parameter\n"));
+        DBG_PRINT("event name must be first parameter\n");
         return ZJS_UNDEFINED;
     }
     int sz = jerry_get_string_size(argv[0]);
     char event[sz];
     int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
     if (len != sz) {
-        DBG_PRINT(("size mismatch\n"));
+        DBG_PRINT("size mismatch\n");
         return ZJS_UNDEFINED;
     }
     event[len] = '\0';
@@ -398,7 +398,7 @@ static jerry_value_t get_listeners(const jerry_value_t function_obj,
     // Event object to hold callback ID and eventually listener arguments
     jerry_value_t event_obj = zjs_get_property(ev->map, event);
     if (!jerry_value_is_object(event_obj)) {
-        DBG_PRINT(("event object not found for '%s'\n", event));
+        DBG_PRINT("event object not found for '%s'\n", event);
         return ZJS_UNDEFINED;
     }
 
@@ -408,7 +408,7 @@ static jerry_value_t get_listeners(const jerry_value_t function_obj,
         // If there already is an event object, get the callback ID
         zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     } else {
-        DBG_PRINT(("callback_id not found for '%s'\n", event));
+        DBG_PRINT("callback_id not found for '%s'\n", event);
         return ZJS_UNDEFINED;
     }
     int count;
@@ -431,7 +431,7 @@ bool zjs_trigger_event(jerry_value_t obj,
     struct event* ev;
     struct event_trigger* trigger = zjs_malloc(sizeof(struct event_trigger));
     if (!trigger) {
-        DBG_PRINT(("could not allocate trigger, out of memory\n"));
+        DBG_PRINT("could not allocate trigger, out of memory\n");
         return false;
     }
 
@@ -441,7 +441,7 @@ bool zjs_trigger_event(jerry_value_t obj,
     jerry_value_t event_emitter = zjs_get_property(obj, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
         zjs_free(trigger);
-        DBG_PRINT(("native handle not found\n"));
+        DBG_PRINT("native handle not found\n");
         return jerry_create_boolean(false);
     }
 
@@ -449,7 +449,7 @@ bool zjs_trigger_event(jerry_value_t obj,
     trigger->argv = zjs_malloc(sizeof(jerry_value_t) * argc);
     if (!trigger->argv) {
         zjs_free(trigger);
-        DBG_PRINT(("could not allocate trigger args, out of memory\n"));
+        DBG_PRINT("could not allocate trigger args, out of memory\n");
         return false;
     }
     for (i = 0; i < argc; ++i) {
@@ -460,13 +460,13 @@ bool zjs_trigger_event(jerry_value_t obj,
     event_obj = zjs_get_property(ev->map, event);
     if (!jerry_value_is_object(event_obj)) {
         zjs_free(trigger);
-        DBG_PRINT(("event object not found\n"));
+        DBG_PRINT("event object not found\n");
         return false;
     }
 
     if (!zjs_obj_get_int32(event_obj, "callback_id", &callback_id)) {
         zjs_free(trigger);
-        DBG_PRINT(("[event] zjs_trigger_event(): Error, callback_id not found\n"));
+        DBG_PRINT("[event] zjs_trigger_event(): Error, callback_id not found\n");
         return false;
     }
 
@@ -477,8 +477,8 @@ bool zjs_trigger_event(jerry_value_t obj,
 
     zjs_signal_callback(callback_id);
 
-    DBG_PRINT(("triggering event '%s', args_cnt=%lu, callback_id=%ld\n",
-            event, trigger->argc, callback_id));
+    DBG_PRINT("triggering event '%s', args_cnt=%lu, callback_id=%ld\n",
+              event, trigger->argc, callback_id);
 
     return jerry_create_boolean(true);
 }
@@ -493,7 +493,7 @@ bool zjs_trigger_event_now(jerry_value_t obj,
     struct event* ev;
     struct event_trigger* trigger = zjs_malloc(sizeof(struct event_trigger));
     if (!trigger) {
-        DBG_PRINT(("could not allocate trigger, out of memory\n"));
+        DBG_PRINT("could not allocate trigger, out of memory\n");
         return false;
     }
 
@@ -502,7 +502,7 @@ bool zjs_trigger_event_now(jerry_value_t obj,
 
     if (!jerry_get_object_native_handle(obj, (uintptr_t*)&ev)) {
         zjs_free(trigger);
-        DBG_PRINT(("native handle not found\n"));
+        DBG_PRINT("native handle not found\n");
         return jerry_create_boolean(false);
     }
 
@@ -510,7 +510,7 @@ bool zjs_trigger_event_now(jerry_value_t obj,
     trigger->argv = zjs_malloc(sizeof(jerry_value_t) * argc);
     if (!trigger->argv) {
         zjs_free(trigger);
-        DBG_PRINT(("could not allocate trigger args, out of memory\n"));
+        DBG_PRINT("could not allocate trigger args, out of memory\n");
         return false;
     }
     for (i = 0; i < argc; ++i) {
@@ -521,14 +521,14 @@ bool zjs_trigger_event_now(jerry_value_t obj,
     event_obj = zjs_get_property(ev->map, event);
     if (!jerry_value_is_object(event_obj)) {
         zjs_free(trigger);
-        DBG_PRINT(("event object not found\n"));
+        DBG_PRINT("event object not found\n");
         return false;
     }
 
     zjs_obj_get_uint32(event_obj, "callback_id", &callback_id);
     if (callback_id == -1) {
         zjs_free(trigger);
-        DBG_PRINT(("callback_id not found\n"));
+        DBG_PRINT("callback_id not found\n");
         return false;
     }
 
@@ -556,7 +556,7 @@ void zjs_make_event(jerry_value_t obj)
     jerry_value_t event_obj = jerry_create_object();
     struct event* ev = zjs_malloc(sizeof(struct event));
     if (!ev) {
-        DBG_PRINT(("could not allocate event handle, out of memory\n"));
+        DBG_PRINT("could not allocate event handle, out of memory\n");
         return;
     }
 

--- a/src/zjs_pool.c
+++ b/src/zjs_pool.c
@@ -176,12 +176,12 @@ void* pool_malloc(uint32_t size)
     pool = lookup_pool(size);
 #endif
     if (pool == POOL_SIZE_TOO_SMALL) {
-        DBG_PRINT(("no pool size big enough for %lu bytes\n", size));
+        DBG_PRINT("no pool size big enough for %lu bytes\n", size);
         return NULL;
     }
     ret = task_mem_pool_alloc(&block, pool, size, TICKS_NONE);
     if (ret != RC_OK) {
-        DBG_PRINT(("task_mem_pool_alloc() returned an error: %u\n", ret));
+        DBG_PRINT("task_mem_pool_alloc() returned an error: %u\n", ret);
         return NULL;
     }
 #ifdef DUMP_MEM_STATS

--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -119,7 +119,8 @@ static jerry_value_t promise_catch(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-void zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post, void* handle)
+void zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post,
+                      void* handle)
 {
     struct promise* new = new_promise();
     jerry_value_t promise_obj = jerry_create_object();
@@ -137,7 +138,8 @@ void zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post, void* handl
     // object being made to a promise may already have a native handle.
     zjs_obj_add_object(obj, promise_obj, "promise");
 
-    DBG_PRINT(("created promise, obj=%d, promise=%p, handle=%p\n", obj, new, handle));
+    DBG_PRINT("created promise, obj=%lu, promise=%p, handle=%p\n", obj, new,
+              handle);
 }
 
 void zjs_fulfill_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
@@ -151,13 +153,15 @@ void zjs_fulfill_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
     if (!handle->then_set) {
         handle->then = jerry_create_external_function(null_function);
     }
-    handle->then_id = zjs_add_callback_once(handle->then, handle, pre_then, post_promise);
+    handle->then_id = zjs_add_callback_once(handle->then, handle, pre_then,
+                                            post_promise);
     handle->then_argv = argv;
     handle->then_argc = argc;
 
     zjs_signal_callback(handle->then_id);
 
-    DBG_PRINT(("fulfilling promise, obj=%d, then_id=%d, argv=%p, nargs=%d\n", obj, handle->then_id, argv, argc));
+    DBG_PRINT("fulfilling promise, obj=%lu, then_id=%lu, argv=%p, nargs=%lu\n",
+              obj, handle->then_id, argv, argc);
 }
 
 void zjs_reject_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
@@ -171,11 +175,13 @@ void zjs_reject_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
     if (!handle->catch_set) {
         handle->catch = jerry_create_external_function(null_function);
     }
-    handle->catch_id = zjs_add_callback_once(handle->catch, handle, pre_catch, post_promise);
+    handle->catch_id = zjs_add_callback_once(handle->catch, handle, pre_catch,
+                                             post_promise);
     handle->catch_argv = argv;
     handle->catch_argc = argc;
 
     zjs_signal_callback(handle->catch_id);
 
-    DBG_PRINT(("rejecting promise, obj=%u, catch_id=%d, argv=%p, nargs=%d\n", obj, handle->catch_id, argv, argc));
+    DBG_PRINT("rejecting promise, obj=%lu, catch_id=%ld, argv=%p, nargs=%lu\n",
+              obj, handle->catch_id, argv, argc);
 }

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -12,9 +12,9 @@
 #define ZJS_UNDEFINED jerry_create_undefined()
 
 #ifdef DEBUG_BUILD
-#define DBG_PRINT(msg) \
+#define DBG_PRINT \
     PRINT("%s:%d %s(): ", __FILE__, __LINE__, __func__); \
-    PRINT msg;
+    PRINT
 #else
 #define DBG_PRINT(fmat ...) do {} while(0);
 #endif


### PR DESCRIPTION
Also, it appears we never require PRINT to be defined as printk in our
code, so remove that ifdef for now.
