### PR TITLE
[callbacks] Added 'this' parameter to zjs_add_callback() (and variants)

### DIFF
--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -274,7 +274,7 @@ static jerry_value_t zjs_aio_pin_on(const jerry_value_t function_obj,
 
         handle->pin_obj = this;
         jerry_set_object_native_handle(this, (uintptr_t)handle, NULL);
-        handle->callback_id = zjs_add_callback(argv[1], handle,
+        handle->callback_id = zjs_add_callback(argv[1], this, handle,
                                                zjs_aio_pre_callback, NULL);
         zjs_aio_ipm_send_async(TYPE_AIO_PIN_SUBSCRIBE, pin, handle);
     }
@@ -300,7 +300,7 @@ static jerry_value_t zjs_aio_pin_read_async(const jerry_value_t function_obj,
         return zjs_error("zjs_aio_pin_read_async: could not allocate handle");
 
     handle->pin_obj = this;
-    handle->callback_id = zjs_add_callback(argv[0], handle,
+    handle->callback_id = zjs_add_callback(argv[0], this, handle,
                                            zjs_aio_pre_callback,
                                            zjs_aio_free_callback);
 

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -83,6 +83,7 @@ bool zjs_remove_callback_list_func(int32_t id, jerry_value_t js_func);
  * @return              New callback ID for this list (or existing ID)
  */
 int32_t zjs_add_callback_list(jerry_value_t js_func,
+                              jerry_value_t this,
                               void* handle,
                               zjs_pre_callback_func pre,
                               zjs_post_callback_func post,
@@ -98,7 +99,9 @@ int32_t zjs_add_callback_list(jerry_value_t js_func,
  *
  * @return              ID associated with this callback, use this ID to reference this CB
  */
-int32_t zjs_add_callback(jerry_value_t js_func, void* handle,
+int32_t zjs_add_callback(jerry_value_t js_func,
+                         jerry_value_t this,
+                         void* handle,
                          zjs_pre_callback_func pre,
                          zjs_post_callback_func post);
 
@@ -114,6 +117,7 @@ int32_t zjs_add_callback(jerry_value_t js_func, void* handle,
  * @return              ID associated with this callback, use this ID to reference this CB
  */
 int32_t zjs_add_callback_once(jerry_value_t js_func,
+                              jerry_value_t this,
                               void* handle,
                               zjs_pre_callback_func pre,
                               zjs_post_callback_func post);

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -73,7 +73,7 @@ void zjs_add_event_listener(jerry_value_t obj, const char* event, jerry_value_t 
         // If there already is an event object, get the callback ID
         zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     }
-    callback_id = zjs_add_callback_list(listener, ev, pre_event, post_event, callback_id);
+    callback_id = zjs_add_callback_list(listener, obj, ev, pre_event, post_event, callback_id);
 
     // Add callback ID to event object
     zjs_obj_add_number(event_obj, callback_id, "callback_id");

--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -153,7 +153,10 @@ void zjs_fulfill_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
     if (!handle->then_set) {
         handle->then = jerry_create_external_function(null_function);
     }
-    handle->then_id = zjs_add_callback_once(handle->then, handle, pre_then,
+
+    handle->then_id = zjs_add_callback_once(handle->then,
+                                            obj, handle,
+                                            pre_then,
                                             post_promise);
     handle->then_argv = argv;
     handle->then_argc = argc;
@@ -175,7 +178,11 @@ void zjs_reject_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
     if (!handle->catch_set) {
         handle->catch = jerry_create_external_function(null_function);
     }
-    handle->catch_id = zjs_add_callback_once(handle->catch, handle, pre_catch,
+
+    handle->catch_id = zjs_add_callback_once(handle->catch,
+                                             obj,
+                                             handle,
+                                             pre_catch,
                                              post_promise);
     handle->catch_argv = argv;
     handle->catch_argc = argc;

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -48,10 +48,11 @@ jerry_value_t* pre_timer(void* h, uint32_t* argc)
  * argc         Number of arguments in argv
  */
 static zjs_timer_t* add_timer(uint32_t interval,
-                                     jerry_value_t callback,
-                                     bool repeat,
-                                     const jerry_value_t argv[],
-                                     uint32_t argc)
+                              jerry_value_t callback,
+                              jerry_value_t this,
+                              bool repeat,
+                              const jerry_value_t argv[],
+                              uint32_t argc)
 {
     int i;
     zjs_timer_t *tm;
@@ -67,7 +68,7 @@ static zjs_timer_t* add_timer(uint32_t interval,
     tm->repeat = repeat;
     tm->completed = false;
     tm->next = zjs_timers;
-    tm->callback_id = zjs_add_callback(callback, tm, pre_timer, NULL);
+    tm->callback_id = zjs_add_callback(callback, this, tm, pre_timer, NULL);
     tm->argc = argc;
     tm->argv = zjs_malloc(sizeof(jerry_value_t) * argc);
     for (i = 0; i < argc; ++i) {
@@ -122,7 +123,7 @@ static jerry_value_t add_timer_helper(const jerry_value_t function_obj,
     jerry_value_t callback = argv[0];
     jerry_value_t timer_obj = jerry_create_object();
 
-    zjs_timer_t* handle = add_timer(interval, callback, repeat, argv, argc - 2);
+    zjs_timer_t* handle = add_timer(interval, callback, this, repeat, argv, argc - 2);
     if (handle->callback_id == -1)
         return zjs_error("native_set_interval_handler: timer alloc failed");
     jerry_set_object_native_handle(timer_obj, (uintptr_t)handle, NULL);


### PR DESCRIPTION
- This feature also changed events/promises, where 'this' is now the
  event emitter object and promise object respectively.

Signed-off-by: James Prestwood james.prestwood@intel.com
