### PR TITLE
[Demo] Cleaned up debug messages for the BLE demo

### DIFF
--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -280,7 +280,7 @@ static void handle_glcd(struct zjs_ipm_message* msg)
             if (!glcd) {
                 error_code = ERROR_IPM_OPERATION_FAILED;
             } else {
-                PRINT("Grove LCD initialized\n");
+                DBG_PRINT("Grove LCD initialized\n");
             }
         }
         break;
@@ -293,7 +293,7 @@ static void handle_glcd(struct zjs_ipm_message* msg)
         } else {
             snprintf(str, MAX_BUFFER_SIZE, "%s", buffer);
             glcd_print(glcd, str, strnlen(str, MAX_BUFFER_SIZE));
-            PRINT("Grove LCD print: %s\n", str);
+            DBG_PRINT("Grove LCD print: %s\n", str);
         }
         break;
     case TYPE_GLCD_CLEAR:

--- a/src/main.c
+++ b/src/main.c
@@ -49,6 +49,10 @@ int main(int argc, char *argv[])
     jerry_value_t result;
     uint32_t len;
 
+    // print newline here to make it easier to find
+    // the beginning of the program
+    PRINT("\n");
+
 #ifdef ZJS_POOL_CONFIG
     zjs_init_mem_pools();
 #ifdef DUMP_MEM_STATS

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -163,8 +163,10 @@ static void ipm_msg_receive_callback(void *context, uint32_t id,
     } else {
         // asynchronous ipm
         aio_handle_t *handle = (aio_handle_t *)msg->user_data;
-        uint32_t pin = msg->data.aio.pin;
         uint32_t pin_value = msg->data.aio.value;
+#ifdef DEBUG_BUILD
+        uint32_t pin = msg->data.aio.pin;
+#endif
 
         switch(msg->type) {
         case TYPE_AIO_PIN_READ:
@@ -173,10 +175,10 @@ static void ipm_msg_receive_callback(void *context, uint32_t id,
             zjs_signal_callback(handle->callback_id);
             break;
         case TYPE_AIO_PIN_SUBSCRIBE:
-            PRINT("ipm_msg_receive_callback: subscribed to events on pin %lu\n", pin);
+            DBG_PRINT("ipm_msg_receive_callback: subscribed to events on pin %lu\n", pin);
             break;
         case TYPE_AIO_PIN_UNSUBSCRIBE:
-            PRINT("ipm_msg_receive_callback: unsubscribed to events on pin %lu\n", pin);
+            DBG_PRINT("ipm_msg_receive_callback: unsubscribed to events on pin %lu\n", pin);
             break;
 
         default:
@@ -195,7 +197,7 @@ static jerry_value_t zjs_aio_pin_read(const jerry_value_t function_obj,
     zjs_obj_get_uint32(this, "pin", &pin);
 
     if (pin < ARC_AIO_MIN || pin > ARC_AIO_MAX) {
-        PRINT("PIN: #%lu\n", pin);
+        DBG_PRINT("PIN: #%lu\n", pin);
         return zjs_error("zjs_aio_pin_read: pin out of range");
     }
 

--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -9,6 +9,14 @@
 
 #define PRINT printf
 
+#ifdef DEBUG_BUILD
+#define DBG_PRINT \
+    PRINT("%s:%d %s(): ", __FILE__, __LINE__, __func__); \
+    PRINT
+#else
+#define DBG_PRINT(fmat ...) do {} while(0);
+#endif
+
 // TODO: We should instead have a macro that changes in debug vs. release build,
 // to save string space and instead print error codes or something for release.
 

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -11,14 +11,6 @@
 
 #define ZJS_UNDEFINED jerry_create_undefined()
 
-#ifdef DEBUG_BUILD
-#define DBG_PRINT \
-    PRINT("%s:%d %s(): ", __FILE__, __LINE__, __func__); \
-    PRINT
-#else
-#define DBG_PRINT(fmat ...) do {} while(0);
-#endif
-
 #ifdef ZJS_LINUX_BUILD
 #include <stdlib.h>
 #define zjs_malloc(sz) malloc(sz)


### PR DESCRIPTION
Moved the DBG_PRINT macro to zjs_common.h for ARC to use as well,
move all unneeded print messages for the demo to debug, and
added a newline to indicate the beginning of the app

Signed-off-by: Jimmy Huang jimmy.huang@intel.com
