### PR TITLE
[README] Fix links to udev files to point to raw files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ $ sudo useradd -G plugdev USERNAME
 #### Add udev rules
 Copy these two files into your /etc/udev.rules directory:
 
-* [99-openocd.rules](https://github.com/arduino/OpenOCD/blob/master/contrib/99-openocd.rules)
-* [99-dfu.rules](https://github.com/01org/CODK-A-ARC/blob/master/bin/99-dfu.rules)
+* [99-openocd.rules](https://raw.githubusercontent.com/arduino/OpenOCD/master/contrib/99-openocd.rules) (from this [Arduino github project](https://github.com/arduino/OpenOCD/blob/master/contrib/99-openocd.rules))
+* [99-dfu.rules](https://raw.githubusercontent.com/01org/CODK-A-ARC/master/bin/99-dfu.rules) (from this [01org github project](https://github.com/01org/CODK-A-ARC/blob/master/bin/99-dfu.rules))
 
 Then run this command:
 


### PR DESCRIPTION
This prevents users from accidentally installing the HTML content to their
udev directory. Not like, uh, er, anyone would ever do that and waste a
few hours of their life debugging it.

Also retain links to the files within their projects so users can find out
more about where they come from.

Signed-off-by: Geoff Gustafson geoff@linux.intel.com
