### PR TITLE
[build] Making changes needed to rebuild when ROM / RAM changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,8 +243,8 @@ $(JS):
 # Find the modules the JS file depends on
 .PHONY: analyze
 analyze: $(JS)
-	@if [ -e $(OUT)/$(BOARD)/$(BOARD).overlay.bak ]; then \
-		if ! cmp $(OUT)/$(BOARD)/$(BOARD).overlay.bak $(BOARD).overlay; then \
+	@if [ -e prj.conf ]; then \
+		if ! grep -q CONFIG_ROM_SIZE=$(ROM) prj.conf || ! grep CONFIG_RAM_SIZE=$(RAM) prj.conf; then \
 			echo "RAM/ROM size has updated, rebuild..."; \
 			rm -rf $(OUT)/$(BOARD)/zephyr; \
 			rm -rf $(OUT)/$(BOARD)/deps; \


### PR DESCRIPTION
Currently if you want to change the ROM / RAM size for an Arduino 101 build you have to do either make clean or make pristine.  This change fixes it so that if either value changes since the last build, it will rebuild to update the values.
Signed-off-by: Brian J Jones <brian.j.jones@intel.com>