### PR TITLE
[trlite] Only warn on failure to update copyright year

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2016-2017, Intel Corporation.
+# Copyright (c) 2016-2018, Intel Corporation.
 # Author: Geoff Gustafson <geoff@linux.intel.com>
 
 # trlite - a local version of the tests we run in Travis

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -415,8 +415,7 @@ function check_copyright() {
         elif ! $(head -1 $f | grep -q $YEAR); then
             if [ "$INTEL" ]; then
                 if head -1 $f | grep -q Intel; then
-                    echo Error: Add $YEAR to copyright in $f!
-                    RVAL=1
+                    echo Warning: Add $YEAR to copyright in $f!
                 fi
             fi
         fi


### PR DESCRIPTION
With patches from 2017 still pending, it doesn't make sense to break the
build when they get merged. Plus the error always annoyed everyone,
probably better to do this as a git commit hook.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>