### PR TITLE
[bluetooth] Fix BLE_ADDR is not set correctly in net-config

### DIFF
--- a/cmake/zjs.cmake
+++ b/cmake/zjs.cmake
@@ -7,7 +7,7 @@ if(ASHELL)
 endif()
 
 if(BLE_ADDR)
-  add_definitions(-DBLE_ADDR=${BLE_ADDR})
+  add_definitions(-DZJS_CONFIG_BLE_ADDRESS="${BLE_ADDR}")
 endif()
 
 if(CB_STATS)


### PR DESCRIPTION
Fixes #1709

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>