### PR TITLE
[build] Fixed build parameter PRINT_FLOAT not working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,10 @@ analyze: $(JS)
 	@if [ "$(SNAPSHOT)" = "on" ]; then \
 		echo "add_definitions(-DZJS_SNAPSHOT_BUILD)" >> $(OUT)/$(BOARD)/generated.cmake; \
 	fi
+	@# Build NEWLIB with float print support, this will increase ROM size
+	@if [ "$(PRINT_FLOAT)" = "on" ]; then \
+		echo "CONFIG_NEWLIB_LIBC_FLOAT_PRINTF=y" >> prj.conf; \
+	fi
 	@# Add bluetooth debug configs if BLE is enabled
 	@if grep -q BUILD_MODULE_BLE $(OUT)/$(BOARD)/generated.cmake; then \
 		if [ "$(VARIANT)" = "debug" ]; then \

--- a/cmake/zjs.cmake
+++ b/cmake/zjs.cmake
@@ -18,8 +18,8 @@ if(NETWORK_BUILD)
   add_definitions(-DNETWORK_BUILD=${NETWORK_BUILD})
 endif()
 
-if(PRINT_FLOAT)
-  add_definitions(-DPRINT_FLOAT=${PRINT_FLOAT})
+if("${PRINT_FLOAT}" STREQUAL "on")
+  add_definitions(-DZJS_PRINT_FLOATS)
 endif()
 
 if("${VARIANT}" STREQUAL "debug")

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -310,7 +310,7 @@ if [ "$RUN" == "all" -o "$RUN" == "1" ]; then
     # also, try printing a float w/ PRINT_FLOAT
     echo "console.log(3.14159);" >> $TMPFILE
 
-    try_command "net" make $VERBOSE JS=$TMPFILE PRINT_FLOAT=on ROM=256
+    try_command "net" make $VERBOSE JS=$TMPFILE PRINT_FLOAT=on ROM=259
 
     # OCF test
     echo "var ocf = require('ocf');" > $TMPFILE


### PR DESCRIPTION
This fixes the issue that Newlib is not being built with float printing
support when PRINT_FLOAT=on is passed to the command line.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>