### PR TITLE
[ble] Fixed default ble set to "none"

### DIFF
--- a/cmake/zjs.cmake
+++ b/cmake/zjs.cmake
@@ -35,7 +35,7 @@ if(ASHELL)
   add_definitions(-DASHELL=${ASHELL})
 endif()
 
-if(BLE_ADDR)
+if(NOT "${BLE_ADDR}" STREQUAL "none")
   add_definitions(-DZJS_CONFIG_BLE_ADDRESS="${BLE_ADDR}")
 endif()
 


### PR DESCRIPTION
Fixes regression bug that if no BLE_ADDR is set, "none" will
be passed to build instead causing an error.

Fixes #1754

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>