### PR TITLE
[build] Fix incorrect GCC version set for Mac builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,10 +75,10 @@ install: >
 
 before_script: >
   source zjs-env.sh &&
-  if [ "$TARGET" != "linux" ]; then
+  if [[ "$TARGET" != "linux" ]]; then
     make update &&
     source deps/zephyr/zephyr-env.sh;
-  else
+  elif [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
     export CXX="g++-5" CC="gcc-5";
   fi
 


### PR DESCRIPTION
GCC5 should only be needed on Ubuntu 14.04 builds, not MacOS
since it uses clang.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>