### PR TITLE
[gpio] Fix memory leak through unnecessary acquire

### DIFF
--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -170,9 +170,7 @@ static ZJS_DECL_FUNC(zjs_aio_open)
     memset(handle, 0, sizeof(aio_handle_t));
     handle->dev = aiodev;
     handle->pin = pin;
-
-    // TODO: verify that not acquiring here is okay
-    handle->pin_obj = pinobj;
+    handle->pin_obj = pinobj;  // weak reference
 
     // make it an emitter object
     zjs_make_emitter(pinobj, zjs_aio_prototype, handle, aio_free_cb);

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -160,8 +160,8 @@ static ZJS_DECL_FUNC(zjs_aio_open)
     }
 
     // create the AIOPin object
-    jerry_value_t pinobj = zjs_create_object();
-    jerry_set_prototype(pinobj, zjs_aio_prototype);
+    ZVAL pin_obj = zjs_create_object();
+    jerry_set_prototype(pin_obj, zjs_aio_prototype);
 
     aio_handle_t *handle = zjs_malloc(sizeof(aio_handle_t));
     if (!handle) {
@@ -170,14 +170,14 @@ static ZJS_DECL_FUNC(zjs_aio_open)
     memset(handle, 0, sizeof(aio_handle_t));
     handle->dev = aiodev;
     handle->pin = pin;
-    handle->pin_obj = pinobj;  // weak reference
+    handle->pin_obj = pin_obj;  // weak reference
 
     // make it an emitter object
-    zjs_make_emitter(pinobj, zjs_aio_prototype, handle, aio_free_cb);
+    zjs_make_emitter(pin_obj, zjs_aio_prototype, handle, aio_free_cb);
 
     // add to the list of opened handles
     ZJS_LIST_APPEND(aio_handle_t, opened_handles, handle);
-    return pinobj;
+    return jerry_acquire_value(pin_obj);
 }
 
 static s32_t aio_poll_routine(void *h)

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -307,8 +307,7 @@ static ZJS_DECL_FUNC(zjs_gpio_open)
     }
     memset(handle, 0, sizeof(gpio_handle_t));
     handle->pin = pin;
-    // FIXME: this seems wrong, it can probably never be freed
-    handle->pin_obj = jerry_acquire_value(pin_obj);
+    handle->pin_obj = pin_obj;  // weak reference
     handle->port = gpiodev;
     handle->callbackId = -1;
     handle->active_low = active_low;
@@ -328,7 +327,7 @@ static ZJS_DECL_FUNC(zjs_gpio_open)
         handle->edge_both = (edge == ZJS_EDGE_BOTH) ? 1 : 0;
     }
 
-    return pin_obj;
+    return jerry_acquire_value(pin_obj);
 }
 
 static void zjs_gpio_cleanup(void *native)

--- a/src/zjs_pwm.c
+++ b/src/zjs_pwm.c
@@ -185,10 +185,14 @@ static ZJS_DECL_FUNC(zjs_pwm_open)
     }
 
     // create the PWMPin object
-    jerry_value_t pin_obj = zjs_create_object();
+    ZVAL pin_obj = zjs_create_object();
     jerry_set_prototype(pin_obj, zjs_pwm_pin_prototype);
 
     pwm_handle_t *handle = zjs_malloc(sizeof(pwm_handle_t));
+    if (!handle) {
+        return zjs_error("out of memory");
+    }
+
     memset(handle, 0, sizeof(pwm_handle_t));
     handle->device = pwmdev;
     handle->pin = pin;
@@ -197,8 +201,7 @@ static ZJS_DECL_FUNC(zjs_pwm_open)
 
     jerry_set_object_native_pointer(pin_obj, handle, &pwm_type_info);
 
-    // TODO: When we implement close, we should release the reference on this
-    return pin_obj;
+    return jerry_acquire_value(pin_obj);
 }
 
 static void zjs_pwm_cleanup(void *native)


### PR DESCRIPTION
Since the native pointer struct held a reference to the pin object,
neither would ever get freed.

Fixes #1363

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>