### PR TITLE
[build] Add support for 96b_carbon and olimex_stm32_e407

### DIFF
--- a/src/zjs_arduino_101.json
+++ b/src/zjs_arduino_101.json
@@ -1,9 +1,0 @@
-{
-    "module": "arduino_101",
-    "targets": ["arduino_101"],
-    "zephyr_conf": {
-        "arduino_101": [
-            "CONFIG_MAIN_STACK_SIZE=4096"
-        ]
-    }
-}

--- a/src/zjs_common.json
+++ b/src/zjs_common.json
@@ -6,7 +6,8 @@
             "CONFIG_STDOUT_CONSOLE=y",
             "CONFIG_NEWLIB_LIBC=y",
             "CONFIG_FLOAT=y",
-            "CONFIG_RING_BUFFER=y"
+            "CONFIG_RING_BUFFER=y",
+            "CONFIG_MAIN_STACK_SIZE=4096"
         ]
     },
     "zjs_config": ["-DENABLE_INIT_FINI"]

--- a/src/zjs_frdm_k64f.json
+++ b/src/zjs_frdm_k64f.json
@@ -4,7 +4,6 @@
     "src": ["src/zjs_pinmux.c"],
     "zephyr_conf": {
         "frdm_k64f": [
-            "CONFIG_MAIN_STACK_SIZE=2048",
             "CONFIG_PINMUX_MCUX_PORTD=y"
         ]
     }

--- a/src/zjs_net_l2.json
+++ b/src/zjs_net_l2.json
@@ -3,8 +3,10 @@
     "description": "Virtual module to require an L2 network driver be present",
     "virtual": "yes",
     "defaults": {
+        "96b_carbon": "net-l2-bluetooth",
         "arduino_101": "net-l2-bluetooth",
         "frdm_k64f": "net-l2-ethernet",
+        "olimex_stm32_e407": "net-l2-ethernet",
         "qemu_x86": "net-l2-tap"
     }
 }

--- a/src/zjs_net_l2_bluetooth.json
+++ b/src/zjs_net_l2_bluetooth.json
@@ -2,9 +2,12 @@
     "module": "net-l2-bluetooth",
     "fulfills": "net-l2",
     "description": "Enables IP over Bluetooth",
-    "targets": ["arduino_101"],
+    "targets": [
+        "arduino_101",
+        "96b_carbon"
+    ],
     "zephyr_conf": {
-        "arduino_101": [
+        "all": [
             "CONFIG_BT=y",
             "CONFIG_BT_SMP=y",
             "CONFIG_BT_PERIPHERAL=y",

--- a/src/zjs_net_l2_ethernet.json
+++ b/src/zjs_net_l2_ethernet.json
@@ -2,8 +2,11 @@
     "module": "net-l2-ethernet",
     "fulfills": "net-l2",
     "description": "Enables onboard Ethernet",
-    "targets": ["frdm_k64f"],
+    "targets": [
+        "frdm_k64f",
+        "olimex_stm32_e407"
+    ],
     "zephyr_conf": {
-        "frdm_k64f": ["CONFIG_NET_L2_ETHERNET=y"]
+        "all": ["CONFIG_NET_L2_ETHERNET=y"]
     }
 }

--- a/src/zjs_ocf.json
+++ b/src/zjs_ocf.json
@@ -36,6 +36,9 @@
         ],
         "arduino_101": [
             "CONFIG_NET_APP_AUTO_INIT=n"
+        ],
+        "96b_carbon": [
+            "CONFIG_NET_APP_AUTO_INIT=n"
         ]
     },
     "header": [


### PR DESCRIPTION
Add additional target configs for ARM boards so that apps that
require BLE or networking support.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>