### PR TITLE
[arc] Set build optimization flag to -Os

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -432,6 +432,7 @@ arc: analyze
 	@echo "&sram0 { reg = <0xa8000400 ($(ARC_RAM) * 1024)>; };" >> arc/arduino_101_sss.overlay
 	@cmake -B$(OUT)/arduino_101_sss \
 		-DBOARD=arduino_101_sss \
+		-DVARIANT=$(VARIANT) \
 		-H./arc && \
 	make -C $(OUT)/arduino_101_sss -j4
 ifeq ($(BOARD), arduino_101)

--- a/arc/CMakeLists.txt
+++ b/arc/CMakeLists.txt
@@ -10,6 +10,16 @@ set(ZEPHYR_BASE $ENV{ZEPHYR_BASE})
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
+# Work-around that replaces -O2 with -Os to shrink build size
+# remove this patch when Zephyr updates to revert
+# back to -Os in upstream
+if(NOT "${VARIANT}" STREQUAL "debug")
+  zephyr_get_compile_options_for_lang_as_string(C options)
+  string(REPLACE "-O2" "-Os" options_new ${options})
+  separate_arguments(options_new)
+  zephyr_compile_options(${options_new})
+endif()
+
 target_compile_options(app PRIVATE -Wall)
 
 target_include_directories(app PRIVATE ${CMAKE_SOURCE_DIR}/../src)


### PR DESCRIPTION
This will be a work-around to manually set the build
flag from -Os to -O2 until patch is merged into Zephyr
upstream.

Fixes #1367

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>