### PR TITLE
[build] Removed unused NETWORK_BUILD

### DIFF
--- a/cmake/zjs.cmake
+++ b/cmake/zjs.cmake
@@ -41,10 +41,6 @@ if(CB_STATS)
   add_definitions(-DCB_STATS=${CB_STATS})
 endif()
 
-if(NETWORK_BUILD)
-  add_definitions(-DNETWORK_BUILD=${NETWORK_BUILD})
-endif()
-
 if("${PRINT_FLOAT}" STREQUAL "on")
   add_definitions(-DZJS_PRINT_FLOATS)
 endif()


### PR DESCRIPTION
This setting was used previously to include
$(ZEPHYR_BASE)/samples/net/common/Makefile.ipstack, but switching
to CMake no longer requires this.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>