### PR TITLE
[ws] Removing unneeded pong

### DIFF
--- a/samples/websockets/NodeWebSocketClient.js
+++ b/samples/websockets/NodeWebSocketClient.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Intel Corporation.
+// Copyright (c) 2017-2018, Intel Corporation.
 
 var WebSocket = require('ws');
 
@@ -19,7 +19,6 @@ ws.on('message', function(data, flags) {
 
 ws.on('ping', function(data, flags) {
     console.log("PING: " + data);
-	ws.pong(data);
 });
 
 ws.on('error', function(error) {

--- a/samples/websockets/NodeWebSocketClient4.js
+++ b/samples/websockets/NodeWebSocketClient4.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Intel Corporation.
+// Copyright (c) 2017-2018, Intel Corporation.
 
 var WebSocket = require('ws');
 
@@ -18,7 +18,6 @@ ws.on('message', function(data, flags) {
 
 ws.on('ping', function(data, flags) {
     console.log("PING: " + data);
-	ws.pong(data);
 });
 
 ws.on('error', function(error) {


### PR DESCRIPTION
Node.js automatically returns a pong when it gets a ping,
calling ws.pong causes two to be sent to the webserver.

Signed-off-by: Brian Jones <brian.j.jones@intel.com>