### PR TITLE
Update WebIDL and modify documentation to fit new "node.js-like" style

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,13 +817,13 @@ reason we have the following possibilities for support:
 | Module    | Linux | [A101](https://store.arduino.cc/usa/arduino-101 "Arduino 101")/[tT](https://software.intel.com/en-us/node/675623 "tinyTILE") | [K64F](https://os.mbed.com/platforms/FRDM-K64F/ "FRDM-K64F")  | [nRF52](http://infocenter.nordicsemi.com/pdf/nRF52_DK_PB_v1.2.pdf "nRF52 DK") | [Due](https://store.arduino.cc/usa/arduino-due "Arduino Due") | [F411RE](http://www.st.com/en/evaluation-tools/nucleo-f411re.html "STM32 Nucleo-F411RE") | [STM32F4](http://www.st.com/en/evaluation-tools/stm32f4discovery.html "STM32F4DISCOVERY") | [OLIMEX E407](https://www.olimex.com/Products/ARM/ST/STM32-E407/open-source-hardware "OLIMEX STM32 E407") | [Carbon](https://www.96boards.org/product/carbon/ "96Boards Carbon") |
 |   :---:   | :---: |  :---:  | :---:| :---: |:---:|  :---: |  :---:  |   :---:   |  :---: |
 |HelloWorld |   X   |    X    |   X  |   X   |  X  |    X   |    X    |     X     |    X   |
-|  ADC      |       |    X    |      |       |     |        |         |           |        |
+|  ADC      |       |    X    |   X  |       |     |        |         |           |        |
 |  PWM      |       |    X    |      |       |     |        |         |           |        |
 |  GPIO     |       |    X    |   X  |       |     |        |         |           |        |
 |  I2C      |       |    X    |   X  |       |     |        |         |           |        |
 |  BLE      |       |    X    |      |       |     |        |         |           |    X   |
 |  UART     |       |    X    |      |   NT  |     |        |         |           |        |
-| Sensor    |       |    X    |      |       |     |        |         |           |        |
+| Sensor    |       |    X    |   X  |       |     |        |         |           |        |
 | Buffer    |   X   |    X    |   X  |   X   |  X  |    X   |    X    |     X     |    X   |
 | Console   |   X   |    X    |   X  |   X   |  X  |    X   |    X    |     X     |    X   |
 | Event     |   X   |    X    |   X  |   X   |  X  |    X   |    X    |     X     |    X   |

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -400,7 +400,7 @@ void signal_callback_priv(zjs_callback_id id,
     int key = 0;
     if (in_thread) CB_LOCK();
     if (id < 0 || id >= cb_size || !cb_map[id]) {
-        DBG_PRINT("callback ID %u does not exist\n", id);
+        DBG_PRINT("callback ID %d does not exist\n", id);
         if (in_thread) CB_UNLOCK();
         return;
     }
@@ -665,10 +665,10 @@ void zjs_defer_work(zjs_deferred_work callback, const void *buffer, u32_t bytes)
         memcpy(defer->data, buffer, bytes);
     }
 #ifdef DEBUG_CALLBACKS
-    DBG_PRINT("deferring work: %d bytes\ncontents: ", len);
+    DBG_PRINT("full packet: %d bytes\ncontents: ", len);
     int count32 = (len + 3) / 4;
     for (int i = 0; i < count32; ++i) {
-        ZJS_PRINT("0x%x ", ((u32_t *)buf)[i]);
+        ZJS_PRINT("0x%08x ", ((u32_t *)buf)[i]);
     }
     ZJS_PRINT("\nbuffer: ");
     count32 = (bytes + 3) / 4;


### PR DESCRIPTION
Hi -- this is a test edit to spark discussion; please don't accept this pull request!

After a short discussion (#1759), I edited three different .md files in the documentation to get feedback.

The thrust of the changes is that I want to fix the WebIDL to make it not only syntactically correct, but also to make it match the textual description of each api.

However, since Geoff Gustafson updated Buffer.md to be more like node.js documentation, I also changed a couple of the files to match this style.

I propose making similar changes across the documentation, but I would like to limit my commitment to what I've done here -- specifically, I want to make the WebIDL match the description, but my manager would prefer that correctness of the documentation itself be left to other folks :-).  For an example of this, see ble.md, where I left the description of the Characteristic API blank (seach for "TODO") (the 2nd TODO was already in the documentation).

Thanks for considering this!
Tim