### PR TITLE
[events] Fix mem leak of overwriting callback id

### DIFF
--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -12,6 +12,7 @@
 #define DEFAULT_MAX_LISTENERS   10
 
 static jerry_value_t zjs_event_emitter_prototype = 0;
+zjs_callback_id emit_id = -1;
 
 typedef struct listener {
     jerry_value_t func;
@@ -43,6 +44,8 @@ static void free_listener(void *ptr)
 static void zjs_event_proto_free_cb(void *native)
 {
     zjs_event_emitter_prototype = 0;
+    zjs_remove_callback(emit_id);
+    emit_id = -1;
 }
 
 static const jerry_object_native_info_t event_proto_type_info = {
@@ -308,8 +311,6 @@ static ZJS_DECL_FUNC(get_listeners)
     return rval;
 }
 
-zjs_callback_id emit_id = -1;
-
 typedef struct emit_event {
     jerry_value_t obj;
     zjs_pre_emit pre;
@@ -468,8 +469,10 @@ static void zjs_event_init_prototype() {
         };
         zjs_event_emitter_prototype = zjs_create_object();
         zjs_obj_add_functions(zjs_event_emitter_prototype, array);
-        jerry_set_object_native_pointer(zjs_event_emitter_prototype, NULL, &event_proto_type_info);
+        jerry_set_object_native_pointer(zjs_event_emitter_prototype, NULL,
+                                        &event_proto_type_info);
         jerry_release_value(zjs_event_emitter_prototype);
+        emit_id = zjs_add_c_callback(NULL, emit_event_callback);
     }
 }
 
@@ -477,7 +480,6 @@ void zjs_make_emitter(jerry_value_t obj, jerry_value_t prototype,
                       void *user_data, zjs_event_free free_cb)
 {
     zjs_event_init_prototype();
-    emit_id = zjs_add_c_callback(NULL, emit_event_callback);
     jerry_value_t proto = zjs_event_emitter_prototype;
     if (jerry_value_is_object(prototype)) {
         jerry_set_prototype(prototype, proto);


### PR DESCRIPTION
Only one event callback was supposed to be created, but the line was
moved to zjs_make_emitter so that it was created for each new emitter
object. For tests that close and open sockets repeatedly, for example,
this eventually caused the system to run out of memory.

Fixes #1737

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>