### PR TITLE
Fix error: "[: -v: unary operator expected" in macOS build

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -29,7 +29,7 @@ if [ ! -d "$ZJS_BASE" ]; then
    exit 1
 fi
 
-if [ ! -v TRAVIS_COMMIT_RANGE ]; then
+if [[ -z ${TRAVIS_COMMIT_RANGE} ]]; then
     TRAVIS_COMMIT_RANGE=$(git log origin/master..HEAD --format='format:%H')
 fi
 


### PR DESCRIPTION
The macOS uses bash 3.x and the '-v' test command is unknown and we
see the error "[: -v: unary operator expected".

Change test to use '-z' to resolve this issue.