### PR TITLE
Use "#!/usr/bin/env python3" for zjsbanner

### DIFF
--- a/scripts/zjsbanner
+++ b/scripts/zjsbanner
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2017, Intel Corporation.
 


### PR DESCRIPTION
On macOS builds python3 is installed in /usr/local/bin/python3 instead
of /usr/bin/python3 (which is where it is on Linux systems).

Use /usr/bin/env as it will find python3 if it is in the path.

Signed-off-by: John L. Villalovos <john@sodarock.com>