### PR TITLE
[sensor] Implements new W3C Generic Sensor API

### DIFF
--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -108,7 +108,7 @@ API Documentation
 ### onreading
 `Sensor.onreading`
 
-The onreading attribute is an EventHandler which is called whenever a new reading is available.
+The onreading attribute is an EventHandler, which is called whenever a new reading is available.
 
 ### onactivate
 `Sensor.onactivate`

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -28,26 +28,19 @@ specific API functions.
 ####Sensor Interface
 ```javascript
 interface Sensor {
-    readonly attribute SensorState state;   // current state of Sensor object
+    readonly attribute boolean activated;   // whether the sensor is activated or not
+    readonly attribute boolean hasReading;  // whether the sensor has readings available
     readonly attribute double timestamp;    // timestamp of the latest reading in milliseconds
     attribute double frequency;             // sampling frequency in hertz
     void start();                           // starts the sensor
     void stop();                            // stops the sensor
-    attribute ChangeCallback onchange;      // callback handler for change events
+    attribute ChangeCallback onreading;     // callback handler for change events
     attribute ActivateCallback onactivate;  // callback handler for activate events
     attribute ErrorCallback onerror;        // callback handler for error events
 };
 
 dictionary SensorOptions {
     double frequency;  // desire frequency, default is 20 if unset
-};
-
-enum SensorState {
-    "unconnected",
-    "activating",
-    "activated",
-    "idle",
-    "errored"
 };
 
 interface SensorErrorEvent {
@@ -112,15 +105,15 @@ dictionary TemperatureSensorOptions : SensorOptions  {
 API Documentation
 -----------------
 
-### onchange
-`Sensor.onchange`
+### onreading
+`Sensor.onreading`
 
-The onchange attribute is an EventHandler which is called whenever a new reading is available.
+The onreading attribute is an EventHandler which is called whenever a new reading is available.
 
 ### onactivate
 `Sensor.onactivate`
 
-The onactivate attribute is an EventHandler which is called when this.[[state]] transitions from "activating" to "activated".
+The onactivate attribute is an EventHandler which is called when the sensor is activated after calling start().
 
 ### onerror
 `Sensor.onerror`
@@ -130,7 +123,7 @@ The onactivate attribute is an EventHandler which is called whenever an exceptio
 ### start
 `void Sensor.start()`
 
-Starts the sensor instance, the sensor will get callback on onchange whenever there's a new reading available.
+Starts the sensor instance, the sensor will get callback on onreading whenever there's a new reading available.
 
 ### stop
 `void Sensor.stop()`

--- a/modules/GenericSensor.js
+++ b/modules/GenericSensor.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017, Intel Corporation.
+// Copyright (c) 2016-2018, Intel Corporation.
 
 // JavaScript library for the tests sensor case
 
@@ -54,40 +54,31 @@ function GenericSensor() {
                     + total + " passed");
     }
 
-    var currentState = null;
+    var isActivated = false;
     var changeFlag = false;
     var errorFlag = true;
-    var defaultState, startState, stopState, middleState, middleNum;
-    var middleNumX, middleNumY, middleNumZ, tmpTimestamp;
+    var middleNum, middleNumX, middleNumY, middleNumZ, tmpTimestamp;
 
     genericSensor.test = function(sensor, sensorType) {
         assert(typeof sensor === "object" && sensor !== null,
                "sensor: be defined");
 
-        currentState = sensor.state;
-        defaultState = sensor.state;
+        isActivated = sensor.activated;
+        assert(typeof isActivated === "boolean",
+               "sensor: activated as " + isActivated);
+        console.log("activated: " + isActivated);
 
-        assert(typeof currentState === "string" && currentState !== null,
-               "sensor: current state as '" + currentState + "'");
-
-        console.log("currentstate: " + currentState);
-
-        middleState = sensor.state;
-        sensor.state = middleState + "love";
-        assert(sensor.state === middleState,
-               "sensor: state is readonly property");
+        sensor.activated = !sensor.activated;
+        assert(sensor.activated === isActivated,
+               "sensor: activated is readonly property ");
 
         sensor.onactivate = function() {
-            currentState = sensor.state
-            console.log("currentstate: " + currentState);
-
-            assert(currentState === "activated",
-                   "sensor: state is activated");
-
+            console.log("activated: " + sensor.activated);
+            assert(sensor.activated === true, "sensor: sensor is activated");
             changeFlag = true;
         };
 
-        sensor.onchange = function() {
+        sensor.onreading = function() {
             tmpTimestamp = sensor.timestamp;
 
             if (changeFlag === true) {
@@ -174,21 +165,12 @@ function GenericSensor() {
         sensor.start();
 
         setTimeout(function() {
-            startState = sensor.state;
-            assert(defaultState !== startState &&
-                   defaultState === "unconnected" &&
-                   startState === "activated",
-                   "sensor: be started");
+            assert(sensor.activated === true, "sensor: is activated");
         }, 1000);
 
         setTimeout(function() {
             sensor.stop();
-
-            stopState = sensor.state;
-            assert(startState !== stopState &&
-                   stopState === "idle" &&
-                   startState === "activated",
-                   "sensor: be stopped");
+            assert(sensor.activated === false, "sensor: is stopped");
         }, 20000);
 
         setTimeout(function() {

--- a/samples/AmbientLight.js
+++ b/samples/AmbientLight.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017, Intel Corporation.
+// Copyright (c) 2016-2018, Intel Corporation.
 
 // Test code to use the AmbientLightSensor (subclass of Generic Sensor) API
 // to communicate with the Grove Light sensor on the Arduino 101
@@ -32,7 +32,7 @@ var sensor = new AmbientLightSensor({
     pin: 'A2'
 });
 
-sensor.onchange = function() {
+sensor.onreading = function() {
     var val = sensor.illuminance;
     if (val <= 1) {
         console.log("(very dark): " + sensor.illuminance);

--- a/samples/BMI160Accelerometer.js
+++ b/samples/BMI160Accelerometer.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017, Intel Corporation.
+// Copyright (c) 2016-2018, Intel Corporation.
 
 // Test code to use the Accelerometer (subclass of Generic Sensor) API
 // to communicate with the BMI160 inertia sensor on the Arduino 101
@@ -11,7 +11,7 @@ var sensor = new Accelerometer({
     frequency: updateFrequency
 });
 
-sensor.onchange = function() {
+sensor.onreading = function() {
     console.log("acceleration (m/s^2): " +
                 " x=" + sensor.x +
                 " y=" + sensor.y +

--- a/samples/BMI160Gyroscope.js
+++ b/samples/BMI160Gyroscope.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017, Intel Corporation.
+// Copyright (c) 2016-2018, Intel Corporation.
 
 // Test code to use the Gyroscope (subclass of Generic Sensor) API
 // to communicate with the BMI160 inertia sensor on the Arduino 101
@@ -11,7 +11,7 @@ var sensor = new Gyroscope({
     frequency: updateFrequency
 });
 
-sensor.onchange = function() {
+sensor.onreading = function() {
     console.log("rotation (rad/s): " +
                 " x=" + sensor.x +
                 " y=" + sensor.y +

--- a/samples/BMI160Temperature.js
+++ b/samples/BMI160Temperature.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Intel Corporation.
+// Copyright (c) 2017-2018, Intel Corporation.
 
 // Test code to use the TemperatureSensor (subclass of Generic Sensor) API
 // to communicate with the BMI160 inertia sensor on the Arduino 101
@@ -12,7 +12,7 @@ var sensor = new TemperatureSensor({
     frequency: updateFrequency
 });
 
-sensor.onchange = function() {
+sensor.onreading = function() {
     console.log("BMI160 temperature (celsius): " + sensor.celsius);
 };
 

--- a/samples/FXOS8700Accelerometer.js
+++ b/samples/FXOS8700Accelerometer.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Intel Corporation.
+// Copyright (c) 2017-2018, Intel Corporation.
 
 // Test code to use the Accelerometer (subclass of Generic Sensor) API
 // to communicate with the FXOS8700 6-Axis Xtrinsic Sensor on the FRDM-K64F
@@ -11,7 +11,7 @@ var sensor = new Accelerometer({
     frequency: updateFrequency
 });
 
-sensor.onchange = function() {
+sensor.onreading = function() {
     console.log("acceleration (m/s^2): " +
                 " x=" + sensor.x +
                 " y=" + sensor.y +

--- a/samples/FXOS8700Magnetometer.js
+++ b/samples/FXOS8700Magnetometer.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Intel Corporation.
+// Copyright (c) 2017-2018, Intel Corporation.
 
 // Test code to use the Magnetometer (subclass of Generic Sensor) API
 // to communicate with the FXOS8700 6-Axis Xtrinsic Sensor on the FRDM-K64F
@@ -11,7 +11,7 @@ var sensor = new Magnetometer({
     frequency: updateFrequency
 });
 
-sensor.onchange = function() {
+sensor.onreading = function() {
     console.log("magnetic field (μT): " +
                 " x=" + sensor.x +
                 " y=" + sensor.y +

--- a/samples/SensorBLEDemo.js
+++ b/samples/SensorBLEDemo.js
@@ -99,11 +99,11 @@ var gyro = new Gyroscope({
 accel.start();
 gyro.start();
 
-accel.onchange = function() {
+accel.onreading = function() {
     SensorCharacteristic.valueChange(1, accel.x, accel.y, accel.z);
 };
 
-gyro.onchange = function() {
+gyro.onreading = function() {
     SensorCharacteristic.valueChange(0, gyro.x, gyro.y, gyro.z);
 };
 

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -96,53 +96,38 @@ void zjs_sensor_free_instance(sensor_instance_t *instance)
 
 sensor_state_t zjs_sensor_get_state(jerry_value_t obj)
 {
-    const int BUFLEN = 20;
-    char buffer[BUFLEN];
-    if (zjs_obj_get_string(obj, "state", buffer, BUFLEN)) {
-        if (strequal(buffer, "unconnected"))
-            return SENSOR_STATE_UNCONNECTED;
-        if (strequal(buffer, "idle"))
-            return SENSOR_STATE_IDLE;
-        if (strequal(buffer, "activating"))
-            return SENSOR_STATE_ACTIVATING;
-        if (strequal(buffer, "activated"))
-            return SENSOR_STATE_ACTIVATED;
-        if (strequal(buffer, "errored"))
-            return SENSOR_STATE_ERRORED;
-        else
-            ERR_PRINT("invalid state set %s\n", buffer);
-    } else {
-        ERR_PRINT("state is undefined\n");
+    ZJS_GET_HANDLE_OR_NULL(obj, sensor_handle_t, handle, sensor_type_info);
+    if (!handle) {
+        ZJS_ASSERT(false, "no handle found");
+        return SENSOR_STATE_ERRORED;
     }
-
-    zjs_obj_add_readonly_string(obj, "state", "errored");
-    return SENSOR_STATE_ERRORED;
+    return handle->state;
 }
 
 void zjs_sensor_set_state(jerry_value_t obj, sensor_state_t state)
 {
-    sensor_state_t old_state = zjs_sensor_get_state(obj);
+    ZJS_GET_HANDLE_OR_NULL(obj, sensor_handle_t, handle, sensor_type_info);
+    if (!handle) {
+        ZJS_ASSERT(false, "no handle found");
+        return;
+    }
+
+    sensor_state_t old_state = handle->state;
     if (old_state == state) {
         return;
     }
 
     // update state property and trigger onactivate event if necessary
-    const char *state_str = NULL;
     switch (state) {
     case SENSOR_STATE_UNCONNECTED:
-        state_str = "unconnected";
-        break;
     case SENSOR_STATE_IDLE:
-        state_str = "idle";
-        break;
     case SENSOR_STATE_ACTIVATING:
-        state_str = "activating";
+    case SENSOR_STATE_ERRORED:
+        zjs_obj_add_readonly_boolean(obj, "activated", false);
+        zjs_obj_add_readonly_boolean(obj, "hasReading", false);
         break;
     case SENSOR_STATE_ACTIVATED:
-        state_str = "activated";
-        break;
-    case SENSOR_STATE_ERRORED:
-        state_str = "errored";
+        zjs_obj_add_readonly_boolean(obj, "activated", true);
         break;
 
     default:
@@ -150,7 +135,6 @@ void zjs_sensor_set_state(jerry_value_t obj, sensor_state_t state)
         ERR_PRINT("invalid state\n");
         return;
     }
-    zjs_obj_add_readonly_string(obj, "state", state_str);
 
     if (old_state == SENSOR_STATE_ACTIVATING &&
         state == SENSOR_STATE_ACTIVATED) {
@@ -167,16 +151,6 @@ void zjs_sensor_set_state(jerry_value_t obj, sensor_state_t state)
         }
     }
 
-    sensor_handle_t *handle = NULL;
-    const jerry_object_native_info_t *tmp;
-    if (!jerry_get_object_native_pointer(obj, (void **)&handle, &tmp)) {
-        ERR_PRINT("no handle found\n");
-        return;
-    }
-    if (tmp != &sensor_type_info) {
-        ERR_PRINT("handle type did not match\n");
-        return;
-    }
     handle->state = state;
 }
 
@@ -185,13 +159,20 @@ void zjs_sensor_trigger_change(jerry_value_t obj)
     u64_t timestamp = k_uptime_get();
     zjs_obj_add_readonly_number(obj, "timestamp", ((double)timestamp));
 
-    ZVAL func = zjs_get_property(obj, "onchange");
+    // Whem the first reading is triggered, this will set to true
+    bool has_reading = false;
+    zjs_obj_get_boolean(obj, "hasReading", &has_reading);
+    if (!has_reading) {
+        zjs_obj_add_readonly_boolean(obj, "hasReading", true);
+    }
+
+    ZVAL func = zjs_get_property(obj, "onreading");
     if (jerry_value_is_function(func)) {
         ZVAL event = zjs_create_object();
-        // if onchange exists, call it
+        // if onreading exists, call it
         ZVAL rval = jerry_call_function(func, obj, NULL, 0);
         if (jerry_value_has_error_flag(rval)) {
-            ERR_PRINT("calling onchange\n");
+            ERR_PRINT("Error calling onreading\n");
         }
     }
 }
@@ -352,9 +333,10 @@ ZJS_DECL_FUNC_ARGS(zjs_sensor_create,
     jerry_value_t sensor_obj = zjs_create_object();
     ZVAL null_val = jerry_create_null();
 
+    zjs_obj_add_readonly_boolean(sensor_obj, "activated", false);
+    zjs_obj_add_readonly_boolean(sensor_obj, "hasReading", false);
     zjs_set_readonly_property(sensor_obj, "timestamp", null_val);
     zjs_obj_add_number(sensor_obj, "frequency", frequency);
-    zjs_obj_add_readonly_string(sensor_obj, "state", "unconnected");
     jerry_set_prototype(sensor_obj, zjs_sensor_prototype);
 
     handle->sensor_obj = jerry_acquire_value(sensor_obj);

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -159,7 +159,7 @@ void zjs_sensor_trigger_change(jerry_value_t obj)
     u64_t timestamp = k_uptime_get();
     zjs_obj_add_readonly_number(obj, "timestamp", ((double)timestamp));
 
-    // Whem the first reading is triggered, this will set to true
+    // When the first reading is triggered, set hasReading to true
     bool has_reading = false;
     zjs_obj_get_boolean(obj, "hasReading", &has_reading);
     if (!has_reading) {

--- a/src/zjs_sensor_board_k64f.c
+++ b/src/zjs_sensor_board_k64f.c
@@ -111,8 +111,7 @@ int zjs_sensor_board_create(sensor_handle_t *handle)
         return -1;
     }
 
-    ZJS_PRINT("handle->controller->name %s\n", handle->controller->name);
-
+    DBG_PRINT("handle->controller->name %s\n", handle->controller->name);
     return 0;
 }
 


### PR DESCRIPTION
In the latest W3C spec, onchange event handler has been renamed to
onreading, and the state property is no longer exposed in the sensor
object.

Fixes #1829

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>