### PR TITLE
[math] Add MathStubs to ashell build

### DIFF
--- a/src/zjs_ashell.json
+++ b/src/zjs_ashell.json
@@ -8,6 +8,7 @@
         "fs",
         "gpio",
         "i2c",
+        "math",
         "performance",
         "pwm",
         "sensor_accel",


### PR DESCRIPTION
This allows random() to be used in Ashell/IDE.

Fixes #1834

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>