### PR TITLE
[build] analyze: Change args.verbose comparison to integer

### DIFF
--- a/scripts/analyze
+++ b/scripts/analyze
@@ -87,7 +87,7 @@ def main():
 
 def do_print(s):
     """Debug print controlled with V option"""
-    if args.verbose == '1':
+    if args.verbose == 1:
         p = pprint.PrettyPrinter(indent=1)
         p.pprint(s)
 


### PR DESCRIPTION
In commit 490ff661a54944456145b060d179c34a8f19101e the args.verbose
parameter was changed to an integer value but the comparison was still
using a string comparison.

Change it to compare with an integer value so that --verbose=1 works
and will print extra output.

Signed-off-by: John L. Villalovos <john@sodarock.com>