### PR TITLE
[modules] Removing long lines from module examples

### DIFF
--- a/modules/BMP280.js
+++ b/modules/BMP280.js
@@ -41,7 +41,7 @@ function BMP280() {
         // These need to be read as a burst read in order to get accurate numbers,
         // so dig_TAll contains dig_T1 through dig_T3
         var dig_TAll = this.i2cDevice.burstRead(this.bmp280Addrs.ADDRESS, 24,
-                                                this.bmp280Addrs.REGISTER_DIG_T1);
+                                            this.bmp280Addrs.REGISTER_DIG_T1);
         dig_T1 = dig_TAll.readUInt16LE();
         dig_T2 = dig_TAll.readUInt16LE(2);
         dig_T3 = dig_TAll.readUInt16LE(4);
@@ -55,7 +55,7 @@ function BMP280() {
     bmp280API.readTemperature = function() {
         // Read the raw temperature value.
         var tempBuffer = this.i2cDevice.burstRead(this.bmp280Addrs.ADDRESS, 4,
-                                                  this.bmp280Addrs.REGISTER_TEMPDATA);
+                                            this.bmp280Addrs.REGISTER_TEMPDATA);
         // Get the number from the buffer object
         var tempDec = tempBuffer.readUInt32BE();
 
@@ -65,8 +65,8 @@ function BMP280() {
         // Convert raw temperature to Celsius using the algorithm found here
         // https://www.bosch-sensortec.com/bst/products/all_products/bmp280
         var var1 = (((tempDec >> 3) - (dig_T1 << 1)) * (dig_T2)) >> 11;
-        var var2 = (((((tempDec >> 4) - (dig_T1)) * ((tempDec >> 4) - (dig_T1))) >> 12) *
-                    (dig_T3)) >> 14;
+        var var2 = (((((tempDec >> 4) - (dig_T1)) * ((tempDec >> 4) -
+                    (dig_T1))) >> 12) * (dig_T3)) >> 14;
 
         var t_fine = var1 + var2;
         var T = ((t_fine * 5 + 128) >> 8) / 100 ;

--- a/modules/GroveLCD.js
+++ b/modules/GroveLCD.js
@@ -59,12 +59,14 @@ function GroveLCD() {
         if (col === undefined && row === undefined && numChar === undefined) {
             // Clear the display completely if no args passed.
             groveLCDAPI.i2cDevice.write(this.glcdAddrs.DISPLAY_ADDR,
-                                        new Buffer([0, this.glcdAddrs.CMD_SCREEN_CLEAR]));
+                                        new Buffer([0,
+                                        this.glcdAddrs.CMD_SCREEN_CLEAR]));
             return;
         }
-        else if (col === undefined || row === undefined || numChar === undefined) {
+        else if (col === undefined || row === undefined ||
+                 numChar === undefined) {
             // If any of the args undefined - print warning and return
-            console.log ("Missing args for GroveLCD.clear. Please pass col, row, numChar");
+            console.log ("Missing clear args. Please pass col, row, numChar");
             return;
         }
 
@@ -99,7 +101,8 @@ function GroveLCD() {
         }
 
         this.i2cDevice.write(this.glcdAddrs.DISPLAY_ADDR,
-                             new Buffer([this.glcdAddrs.CMD_SET_DDRAM_ADDR, col]));
+                             new Buffer([this.glcdAddrs.CMD_SET_DDRAM_ADDR,
+                             col]));
     }
 
     groveLCDAPI.setColor = function(colorObj) {
@@ -115,7 +118,8 @@ function GroveLCD() {
         }
         if (colorObj.green && colorObj.green > -1 && colorObj.green < 256) {
             this.i2cDevice.write(this.glcdAddrs.BACKLIGHT_ADDR,
-                                 new Buffer([this.glcdAddrs.REGISTER_G, green]));
+                                 new Buffer([this.glcdAddrs.REGISTER_G,
+                                 green]));
         }
     }
 


### PR DESCRIPTION
Fix for #1833.  This will ultimately be fixed by the upcoming ASHELL / IDE refactor, but for now this is necessary to keep the IDE from chopping off lines longer than 81 chars.
Signed-off-by: Brian J Jones <brian.j.jones@intel.com>