### PR TITLE
[build] Only checkout submodule if not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,9 @@ analyze: $(JS)
 # Update dependency repos
 .PHONY: update
 update: .gitmodules
-	@git submodule update --init --recursive
+	@if ! [ -f ${JERRY_BASE}/CMakeLists.txt ]; then \
+		git submodule update --init --recursive; \
+	fi
 
 ${JERRY_BASE}/CMakeLists.txt: update
 


### PR DESCRIPTION
This fixes a non-desired behavior that git submodule update
will always be called when building, and it will immediately
checkout jerryscript at the desired commit, causing that repo
to switch from the working branch into a detached head state.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>