### PR TITLE
[snapshot] Fixed incorrect snapshot size

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -275,7 +275,7 @@ int main(int argc, char *argv[])
 #else
 #ifndef ZJS_ASHELL
         script_len = strnlen(script_jscode, MAX_SCRIPT_SIZE);
-        script = script_jscode;
+        script = (char *)script_jscode;
 #endif
 #endif
         if (script_len == MAX_SCRIPT_SIZE) {

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -279,7 +279,7 @@ void zjs_modules_check_load_file()
     size_t size;
     jerry_value_t parsed_code = 0;
     buf = read_file_alloc(load_file, &size);
-    parsed_code = jerry_parse(NULL, 0, const jerry_char_t *)buf, size,
+    parsed_code = jerry_parse(NULL, 0, (const jerry_char_t *)buf, size,
                               JERRY_PARSE_NO_OPTS);
     zjs_free(buf);
 

--- a/tools/snapshot.c
+++ b/tools/snapshot.c
@@ -39,19 +39,28 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    size_t size = jerry_generate_snapshot(NULL,
-                                          0,
-                                          (const jerry_char_t *)script,
-                                          len,
-                                          0,
-                                          snapshot_buf,
-                                          sizeof(snapshot_buf));
+    jerry_value_t snapshot_result;
+    snapshot_result = jerry_generate_snapshot(NULL,
+                                              0,
+                                              (const jerry_char_t *)script,
+                                              len,
+                                              0,
+                                              snapshot_buf,
+                                              sizeof(snapshot_buf));
+
+    if (jerry_value_is_error(snapshot_result)) {
+        fprintf(stderr, "JerryScript: failed to parse JS and create snapshot\n");
+        return 1;
+    }
+
+    size_t size = (size_t)jerry_get_number_value(snapshot_result);
+    jerry_release_value(snapshot_result);
 
     if (script != NULL)
         free(script);
 
     if (size == 0) {
-        fprintf(stderr, "JerryScript: failed to parse JS and create snapshot\n");
+        fprintf(stderr, "JerryScript: snapshot size is zero\n");
         return 1;
     }
 


### PR DESCRIPTION
JerryScript updated the generate_snapshot API to return
a jerry_value instead of the size, so if you directly
use the size returned, it will be incorrect.

Fixes #1888

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>