### PR TITLE
Fixed small things on grove and web-socket and redid webusb, which I somehow missed on the first go around.

### DIFF
--- a/docs/grove_lcd.md
+++ b/docs/grove_lcd.md
@@ -15,7 +15,6 @@ ZJS API for Grove LCD
   * [groveLCDDevice.getFunction()](#grovelcddevicegetfunction)
   * [groveLCDDevice.setDisplayState(config)](#grovelcddevicesetdisplaystateconfig)
   * [GroveLCDDevice.getDisplayState()](#grovelcddevicegetdisplaystate)
-
 * [Sample Apps](#sample-apps)
 
 Introduction

--- a/docs/web-socket.md
+++ b/docs/web-socket.md
@@ -36,7 +36,7 @@ explaining [ZJS WebIDL conventions](Notes_on_WebIDL.md).
 // var ws = require('ws');
 [ReturnFromRequire]
 interface WebSocket {
-    WebSocketServer Server(object options);
+    WebSocketServer Server(OptionsObject options);
 };<p>
 [ExternalInterface=(EventEmitter)]
 interface WebSocketServer: EventEmitter{};<p>[ExternalInterface=(Buffer),]
@@ -44,7 +44,14 @@ interface WebSocketConnection: EventEmitter {
     void send(Buffer data, boolean mask);
     void ping(Buffer data, boolean mask);
     void pong(Buffer data, boolean mask);
-};</pre>
+};<p>dictionary OptionsObject {
+    double port;               // Port to bind to
+    boolean backlog;            // Max number of concurrent connections
+    boolean clientTracking;  // enable client tracking
+    double maxPayload;         // set the max payload bytes per message
+    string acceptHandler;    // handler to call to accept/deny connections
+};
+</pre>
 </details>
 
 WebSocket API

--- a/docs/webusb.md
+++ b/docs/webusb.md
@@ -2,8 +2,10 @@ Zephyr.js API for WebUSB
 ========================
 
 * [Introduction](#introduction)
-* [Class: WebUSB](#class-webusb)
-* [API Documentation](#api-documentation)
+* [Class: WebUSB](#webusb-api)
+  * [webusb.setURL(url)](#webusbseturlurl)
+  * [webusb.write(buffer)](#webusbwritebuffer)
+  * [Event: 'read'](#event-read)
 * [Sample Apps](#sample-apps)
 
 Introduction
@@ -19,30 +21,39 @@ When you connect your device to a Linux PC or Mac with Chrome >= 60 running, it
 will give a notification that the device would like you to visit the URL you've
 set. (Windows currently prevents this from working, I believe.)
 
-API Documentation
------------------
+Web IDL
+-------
+This IDL provides an overview of the interface; see below for documentation of
+specific API functions.  We also have a short document explaining [ZJS WebIDL conventions](Notes_on_WebIDL.md).
+<details>
+<summary> Click to show/hide WebIDL</summary>
+<pre>
+// require returns a webusb object
+// var webusb = require('webusb');<p>[ReturnFromRequire, ExternalInterface=(Buffer)]
+interface webusb {
+    void setURL(string url);
+    void write(Buffer buf);
+};
+</pre>
+</details>
+
+webusb API
+----------
+
+### webusb.setURL(url)
+* `url` *string* Should begin with "https://" for Chrome to accept it
+and display a notification. Other URLs are valid in terms of the protocol but
+will have no user-visible effect in Chrome.
+
+### webusb.write(buffer)
+* `write` *Buffer*  Writes the data in `buffer` to the WebUSB TX line. By default, at most 511 bytes can be pending at one time, so that is the maximum write size, assuming all previous data has already been flushed out. An error will be thrown on overflow.
+
 ### Event: 'read'
 
 * `Buffer` `data`
 
 Emitted when data is received on the WebUSB RX line. The `data` parameter is a
 `Buffer` with the received data.
-
-### WebUSB.setURL
-
-`void setURL(string url);`
-
-The `url` string should begin with "https://" in order for Chrome to accept it
-and display a notification. Other URLs are valid in terms of the protocol but
-will have no user-visible effect in Chrome.
-
-### WebUSB.write
-
-`void write(Buffer buffer);`
-
-Writes the data in `buffer` to the WebUSB TX line. By default at most 511 bytes
-can be pending at one time, so that is the maximum write size, assuming all
-previous data had already been flushed out. An error will be thrown on overflow.
 
 Sample Apps
 -----------


### PR DESCRIPTION
For grove_lcd, the single blank line caused all of the links to be double-spaced.

For web-socket, I noticed that the actual C code was passing around the OptionsObject, which existed in some previous version of the docs, so I reinstated it.

For webusb, well, that was just one I missed; it isn't any different than all of the rest.